### PR TITLE
New grammar for ip and domains validation

### DIFF
--- a/ui/view/controls/IPAddrInput.qml
+++ b/ui/view/controls/IPAddrInput.qml
@@ -14,7 +14,7 @@ ColumnLayout {
     readonly property bool  isValid: addressInput.acceptableInput
 
     property var ipValidator: RegExpValidator {regExp: /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/g}
-    property var ipDomainValidator: RegExpValidator {regExp: /^((((([A-Za-z0-9-]{1,63}(?!-)\.)+[A-Za-z]{2,6}))|((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))))$/g}
+    property var ipDomainValidator: RegExpValidator {regExp: /(^(?=.{0,255}$)(?!.*((^-)|(\.-)|(-\.)).*)([\w-]{1,63}\.)+[A-Za-z_][\w-]{0,61}[\w]$)|(^((?!(.*\.){4})(([0-1]?[\d]?[\d]|2[0-4][\d]|25[0-5])(\.|(?=$))){4})$)/g}
 
     property alias readOnly: addressInput.readOnly
     property alias underlineVisible: addressInput.underlineVisible


### PR DESCRIPTION
Fix of issue #5 
Javascript-regex that accepts domains that follow `RFC952`, `RFC1034`, `RFC1123` and `RFC2181` and that accepts any IPv4 (decimal notation).

It has these additional restrictions on the TLD only, following the current 'IANA root zones' database as discussed in #5 :
- TLD cannot start with a digit.
- TLD must be longer than 1 unit.