### PR TITLE
domains: forbid '_' and allow root only

### DIFF
--- a/ui/view/controls/IPAddrInput.qml
+++ b/ui/view/controls/IPAddrInput.qml
@@ -14,7 +14,7 @@ ColumnLayout {
     readonly property bool  isValid: addressInput.acceptableInput
 
     property var ipValidator: RegExpValidator {regExp: /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/g}
-    property var ipDomainValidator: RegExpValidator {regExp: /(^(?=.{0,255}$)(?!.*((^-)|(\.-)|(-\.)).*)([\w-]{1,63}\.)+[A-Za-z_][\w-]{0,61}[\w]$)|(^((?!(.*\.){4})(([0-1]?[\d]?[\d]|2[0-4][\d]|25[0-5])(\.|(?=$))){4})$)/g}
+    property var ipDomainValidator: RegExpValidator {regExp: /(^((?=.{0,255}$)(?!.*(_|(^-)|(\.-)|(-\.)).*)((([\w-]{1,63}\.)+[A-Za-z_][\w-]{0,61}[\w])|([\w-]{0,62}[\w])))$)|(^((?!(.*\.){4})(([0-1]?[\d]?[\d]|2[0-4][\d]|25[0-5])(\.|(?=$))){4})$)/g}
 
     property alias readOnly: addressInput.readOnly
     property alias underlineVisible: addressInput.underlineVisible


### PR DESCRIPTION
As #84 but:

- underline is forbidden, it doesn't belong to the alphabet anymore.
- root only domains (except the empty string) are allowed.

(related to #5 )