### PR TITLE
#1081 updated message for 'enter old password'

### DIFF
--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -302,12 +302,14 @@
         <translation>Новы пароль не супадае з пацвярдженнем</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Стары пароль уведзены няправільна</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Стары пароль уведзены няправільна</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Увядзіце стары пароль</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Увядзіце стары пароль</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -302,12 +302,14 @@
         <translation>Nové heslo se neshoduje s heslem pro potvrzení</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Zadané staré heslo je nesprávné</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Zadané staré heslo je nesprávné</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Zadejte staré heslo</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Zadejte staré heslo</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -302,12 +302,14 @@
         <translation>Neues Passwort stimmt nicht überein</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Das eingegebene Passwort ist nicht korrekt</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Das eingegebene Passwort ist nicht korrekt</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Altes Passwort eingeben</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Altes Passwort eingeben</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -302,12 +302,14 @@
         <translation>New password doesn&apos;t match the confirm password</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>The old password you have entered is incorrect</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation>Current password is incorrect</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Enter old password</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation>Enter your current password</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -302,12 +302,14 @@
         <translation>La nueva contraseña no coincide con la contraseña confirmada</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>La antigua contraseña que has introducido no es correcta</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">La antigua contraseña que has introducido no es correcta</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Introduce la contraseña antigua</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Introduce la contraseña antigua</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -302,12 +302,14 @@
         <translation>Salasanat eivät täsmää</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Kirjoittamasi vanha salasana on virheellinen</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Kirjoittamasi vanha salasana on virheellinen</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Kirjoita vanha salasanasi</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Kirjoita vanha salasanasi</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -302,12 +302,14 @@
         <translation>Le mot de passe que vous avez entré ne correspond pas à celui confirmé</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>L&apos;ancien mot de passe que vous avez entré est incorrect</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">L&apos;ancien mot de passe que vous avez entré est incorrect</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Entrez votre ancien mot de passe</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Entrez votre ancien mot de passe</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -302,12 +302,14 @@
         <translation>password tidak cocok</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>sandi lama anda salah.</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">sandi lama anda salah.</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Masukkan sandi lama</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Masukkan sandi lama</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -302,12 +302,14 @@
         <translation>La nuova password non corrisponde alla password di conferma</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>La vecchia password immessa non è corretta</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">La vecchia password immessa non è corretta</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Inserire la vecchia password</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Inserire la vecchia password</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -302,12 +302,14 @@
         <translation>新しいパスワードが一致しません</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>入力したパスワードが間違っています</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">入力したパスワードが間違っています</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>古いパスワードを入力してください</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">古いパスワードを入力してください</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -302,12 +302,14 @@
         <translation>새로운 비밀번호가 확인 비밀번호와 일치하지 않습니다</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>입력한 이전 비밀번호가 정확하지 않습니다</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">입력한 이전 비밀번호가 정확하지 않습니다</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>옛날 비밀번호를 입력하세요</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">옛날 비밀번호를 입력하세요</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -302,12 +302,14 @@
         <translation>Het nieuwe wachtwoord komt niet overeen met het bevestigde wachtwoord</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Het ingevoerde oude wachtwoord is onjuist</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Het ingevoerde oude wachtwoord is onjuist</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Voer oude wachtwoord in</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Voer oude wachtwoord in</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -302,12 +302,14 @@
         <translation>A nova senha não corresponde à senha confirmada</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>A senha antiga que você digitou está incorreta</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">A senha antiga que você digitou está incorreta</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Digite a senha antiga</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Digite a senha antiga</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/rs_RS.ts
+++ b/ui/i18n/rs_RS.ts
@@ -359,12 +359,14 @@
         <translation>Нова лозинка се не слаже са лозинком за конфирмацију</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Стара лозинка коју сте унели је погрешна</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Стара лозинка коју сте унели је погрешна</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Унесите стару лозинку</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Унесите стару лозинку</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -302,12 +302,14 @@
         <translation>Неверное подтверждение нового пароля</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Старый пароль введен неправильно</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Старый пароль введен неправильно</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Введите старый пароль</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Введите старый пароль</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -303,12 +303,14 @@
         <translation>Нова лозинка се не слаже са лозинком за конфирмацију</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Стара лозинка коју сте унели је погрешна</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Стара лозинка коју сте унели је погрешна</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Унесите стару лозинку</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Унесите стару лозинку</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -302,12 +302,14 @@
         <translation>Ditt nya lösenord matchar inte verifierings-lösenordet</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Det gamla lösenordet du angivit är felaktigt</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Det gamla lösenordet du angivit är felaktigt</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Mata in ditt gamla lösenord</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Mata in ditt gamla lösenord</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -302,12 +302,14 @@
         <translation>รหัสผ่านใหม่กับยืนยันรหัสผ่านใหม่ไม่ตรงกัน</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>รหัสผ่านเก่าที่คุณกรอกไม่ถูกต้อง</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">รหัสผ่านเก่าที่คุณกรอกไม่ถูกต้อง</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>กรอกรหัสผ่านเก่า</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">กรอกรหัสผ่านเก่า</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -302,12 +302,14 @@
         <translation>Yeni şifre eşleşmiyor, onaylamak için lütfen eşleştirin</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Girdiğiniz eski şifre yanlış</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Girdiğiniz eski şifre yanlış</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Eski şifrenizi girin</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Eski şifrenizi girin</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -302,12 +302,14 @@
         <translation>Новий пароль не підтверджено</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Старий пароль введено неправильно</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Старий пароль введено неправильно</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Введіть старий пароль</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Введіть старий пароль</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -303,12 +303,14 @@
         <translation>Mật khẩu mới không khớp với mật khẩu xác nhận</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>Mật khẩu cũ bạn đã nhập không chính xác</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">Mật khẩu cũ bạn đã nhập không chính xác</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>Nhập mật khẩu cũ</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">Nhập mật khẩu cũ</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -303,12 +303,14 @@
         <translation>两次密码不匹配</translation>
     </message>
     <message id="change-pwd-old-fail">
-        <source>The old password you have entered is incorrect</source>
-        <translation>您输入的旧密码不正确</translation>
+        <source>Current password is incorrect</source>
+        <oldsource>The old password you have entered is incorrect</oldsource>
+        <translation type="unfinished">您输入的旧密码不正确</translation>
     </message>
     <message id="change-pwd-old-pwd-label">
-        <source>Enter old password</source>
-        <translation>请输入旧密码</translation>
+        <source>Enter your current password</source>
+        <oldsource>Enter old password</oldsource>
+        <translation type="unfinished">请输入旧密码</translation>
     </message>
     <message id="change-pwd-new-pwd-label">
         <source>Enter new password</source>

--- a/ui/view/controls/ChangePasswordDialog.qml
+++ b/ui/view/controls/ChangePasswordDialog.qml
@@ -43,7 +43,7 @@ CustomDialog {
             width: parent.width
             spacing: 8
             SFText {
-                //% "Enter old password"
+                //% "Enter your current password"
                 text: qsTrId("change-pwd-old-pwd-label")
                 color: Style.content_main
                 font.pixelSize: 12
@@ -143,7 +143,7 @@ CustomDialog {
                     }
                     else if(!settingsViewModel.checkWalletPassword(oldPass.text))
                     {
-                        //% "The old password you have entered is incorrect"
+                        //% "Current password is incorrect"
                         error.text = qsTrId("change-pwd-old-fail");
                     }
                     else if(newPass.text == oldPass.text)


### PR DESCRIPTION
**Fixes: #1081**

Change wallet password window:
![Issue#1081_1](https://github.com/BeamMW/beam-ui/assets/45984955/15005246-0c3e-4bcf-942a-fb37d78b85ff)

Incorrect current password message:
![Issue#1081_2](https://github.com/BeamMW/beam-ui/assets/45984955/92456c2e-6702-4c5d-bf19-a77e0ad64ced)
