### PR TITLE
Add remove current wallet action to utilities

### DIFF
--- a/ui/view/controls/ConfirmPasswordDialog.qml
+++ b/ui/view/controls/ConfirmPasswordDialog.qml
@@ -5,6 +5,7 @@
     import "."
 
     CustomDialog {
+    id: control
     property var settingsViewModel: function() {
         return {
             checkWalletPassword: function() {
@@ -16,11 +17,13 @@
 
     property string dialogTitle: "title"
     property string dialogMessage: "message"
+    property color okButtonColor: Style.active
     property alias okButtonText: okButton.text
     property alias okButtonIcon: okButton.icon.source
     property alias cancelButtonText: cancelButton.text
     property alias cancelButtonIcon: cancelButton.icon.source
     property alias pwd: pwd.text
+    property alias passwordPlaceholderText: pwd.placeholderText
     property bool showError: false
     property var onDialogAccepted: function() {
         console.log("Accepted");
@@ -65,6 +68,7 @@
                 Layout.fillWidth:       true
                 Layout.alignment:       Qt.AlignHCenter
                 text:                   dialogMessage
+                visible:                dialogMessage.length > 0
                 color:                  Style.content_main
                 font.pixelSize:         14
                 wrapMode:               Text.Wrap
@@ -130,6 +134,7 @@
                 //: confirm password dialog, ok button
                 //% "Proceed"
                 text: qsTrId("general-proceed")
+                palette.button: control.okButtonColor
                 enabled: !showError
                 icon.source: "qrc:/assets/icon-done.svg"
                 onClicked: {

--- a/ui/view/controls/SettingsUtilities.qml
+++ b/ui/view/controls/SettingsUtilities.qml
@@ -18,12 +18,62 @@ SettingsFoldable {
         settingsViewModel: viewModel
     }
 
+    ConfirmationDialog {
+        id: removeWalletConfirmationDialog
+        parent: main
+        //% "Remove current wallet"
+        title: qsTrId("settings-remove-wallet")
+        //% "All data will be erased. Make sure you've saved your seed phrase if you want to restore this wallet later on!"
+        text: qsTrId("settings-remove-wallet-confirm-message") + "\n\n" +
+              //% "Are you sure you want to remove your wallet?"
+              qsTrId("settings-remove-wallet-confirm-question")
+        //% "proceed"
+        okButtonText: qsTrId("settings-remove-wallet-proceed")
+        okButtonIconSource: "qrc:/assets/icon-next-white.svg"
+        okButtonColor: Style.swapStateIndicator
+        cancelButtonIconSource: "qrc:/assets/icon-cancel-white.svg"
+        cancelButtonVisible: true
+        width: 460
+        height: 252
+
+        onAccepted: {
+            removeWalletPasswordDialog.open()
+        }
+    }
+
+    ConfirmPasswordDialog {
+        id: removeWalletPasswordDialog
+        parent: main
+        settingsViewModel: viewModel
+        //% "Confirm wallet removal"
+        dialogTitle: qsTrId("settings-remove-wallet-password-title")
+        dialogMessage: ""
+        //% "Enter your password to remove the wallet"
+        passwordPlaceholderText: qsTrId("settings-remove-wallet-password-placeholder")
+        //% "remove"
+        okButtonText: qsTrId("settings-remove-wallet-password-button")
+        okButtonIcon: "qrc:/assets/icon-delete.svg"
+        okButtonColor: Style.swapStateIndicator
+
+        onDialogAccepted: {
+            viewModel.removeCurrentWallet()
+        }
+        onDialogRejected: {}
+    }
+
     PublicOfflineAddressDialog {
         id: publicOfflineAddressDialog;
     }
 
     UtxoDialog {
         id: utxoDialog
+    }
+
+    Connections {
+        target: viewModel
+        function onCurrentWalletRemoved() {
+            main.parent.setSource("qrc:/start.qml")
+        }
     }
 
     content: ColumnLayout {
@@ -89,6 +139,16 @@ SettingsFoldable {
             bold: true
             onClicked: {
                 utxoDialog.open()
+            }
+        }
+
+        LinkButton {
+            //% "Remove current wallet"
+            text: qsTrId("settings-remove-wallet")
+            linkColor: Style.validator_error
+            bold: true
+            onClicked: {
+                removeWalletConfirmationDialog.open()
             }
         }
     }

--- a/ui/viewmodel/settings_view.cpp
+++ b/ui/viewmodel/settings_view.cpp
@@ -68,6 +68,7 @@ SettingsViewModel::SettingsViewModel()
     connect(m_walletModel, SIGNAL(publicAddressChanged(const QString&)), SLOT(onPublicAddressChanged(const QString&)));
     connect(&m_settings, SIGNAL(beamMWLinksChanged()), SIGNAL(beamMWLinksPermissionChanged()));
     connect(m_walletModel, &WalletModel::walletStatusChanged, this, &SettingsViewModel::stateChanged);
+    connect(&AppModel::getInstance(), &AppModel::walletResetCompleted, this, &SettingsViewModel::currentWalletRemoved);
 
     m_timerId = startTimer(CHECK_INTERVAL);
 
@@ -572,6 +573,11 @@ bool SettingsViewModel::importData() const
 void SettingsViewModel::changeWalletPassword(const QString& pass)
 {
     AppModel::getInstance().changeWalletPassword(pass.toStdString());
+}
+
+void SettingsViewModel::removeCurrentWallet()
+{
+    AppModel::getInstance().resetWallet();
 }
 
 #ifdef BEAM_ASSET_SWAP_SUPPORT

--- a/ui/viewmodel/settings_view.h
+++ b/ui/viewmodel/settings_view.h
@@ -165,6 +165,7 @@ public:
     Q_INVOKABLE bool hasPeer(const QString& peer) const;
     Q_INVOKABLE void reportProblem();
     Q_INVOKABLE void changeWalletPassword(const QString& pass);
+    Q_INVOKABLE void removeCurrentWallet();
 #ifdef BEAM_ASSET_SWAP_SUPPORT
     Q_INVOKABLE void allowAssetId(quint32 asset);
     Q_INVOKABLE void disallowAssetId(quint32 asset);
@@ -207,6 +208,7 @@ signals:
     void minConfirmationsChanged();
     void stateChanged();
     void appsPortChanged();
+    void currentWalletRemoved();
 
     #ifdef BEAM_IPFS_SUPPORT
     void IPFSSwarmPortChanged();


### PR DESCRIPTION
Fixes #823.

Summary:
- Adds the "Remove current wallet" action to Utilities.
- Shows a confirmation dialog before requesting the wallet password.
- Uses the existing wallet reset flow and returns to the start screen after reset completes.

Verification:
- Ran `git diff --check`.
- Full local build was not run because CMake/Qt tools are not installed in this environment.
