### PR TITLE
Add settings search filter

### DIFF
--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -385,6 +385,14 @@
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
+    <message id="settings-search-placeholder">
+        <source>Search settings</source>
+        <translation>Search settings</translation>
+    </message>
+    <message id="settings-search-no-results">
+        <source>No matching settings</source>
+        <translation>No matching settings</translation>
+    </message>
     <message id="cant-send-to-expired-message">
         <source>Can&apos;t send to the expired address.</source>
         <translation>Can&apos;t send to the expired address.</translation>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -385,6 +385,14 @@
         <source>Settings</source>
         <translation>설정</translation>
     </message>
+    <message id="settings-search-placeholder">
+        <source>Search settings</source>
+        <translation>설정 검색</translation>
+    </message>
+    <message id="settings-search-no-results">
+        <source>No matching settings</source>
+        <translation>일치하는 설정이 없습니다</translation>
+    </message>
     <message id="cant-send-to-expired-message">
         <source>Can&apos;t send to the expired address.</source>
         <translation>만료된 주소에는 보낼 수 없습니다.</translation>

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -14,6 +14,8 @@ ColumnLayout {
     property string  linkStyle: "<style>a:link {color: '#00f6d2'; text-decoration: none;}</style>"
     property string  unfoldSection:   ""
     property bool    creating: true
+    property string  searchText: ""
+    readonly property bool searchActive: searchText.trim().length > 0
 
     property bool settingsPrivacyFolded: true
 
@@ -23,6 +25,83 @@ ColumnLayout {
 
     SettingsViewModel {
         id: viewModel
+    }
+
+    function searchTerms() {
+        var query = searchText.trim().toLowerCase()
+        if (!query.length) return []
+        var words = query.split(/\s+/)
+        return words.indexOf(query) === -1 ? [query].concat(words) : words
+    }
+
+    function itemMatches(item, terms) {
+        if (!item || !terms.length) return false
+
+        var values = []
+        if (item.title !== undefined) values.push(item.title)
+        if (item.text !== undefined) values.push(item.text)
+        if (item.displayText !== undefined) values.push(item.displayText)
+        if (item.currentText !== undefined) values.push(item.currentText)
+
+        for (var i = 0; i < values.length; ++i) {
+            var value = String(values[i]).toLowerCase()
+            for (var j = 0; j < terms.length; ++j) {
+                if (value.indexOf(terms[j]) !== -1) return true
+            }
+        }
+
+        if (!item.children) return false
+        for (var k = 0; k < item.children.length; ++k) {
+            if (itemMatches(item.children[k], terms)) return true
+        }
+        return false
+    }
+
+    function blockMatches(block) {
+        return !searchActive || itemMatches(block, searchTerms())
+    }
+
+    function hasSearchResults() {
+        if (!searchActive) return true
+
+        var blocks = [
+            generalBlock, notificationsBlock, utilitiesBlock, privacyBlock,
+            appsBlock, caBlock, resourcesBlock, reportBlock, remoteNodeBlock,
+            nodeBlock, ipfsBlock, swapEthSettings
+        ]
+
+        for (var i = 0; i < blocks.length; ++i) {
+            if (blockMatches(blocks[i])) return true
+        }
+
+        for (var j = 0; j < swapSettingsList.count; ++j) {
+            if (blockMatches(swapSettingsList.itemAt(j))) return true
+        }
+
+        return false
+    }
+
+    function applySearchToBlock(block, defaultFolded) {
+        if (searchActive) {
+            block.folded = !blockMatches(block)
+        } else if (defaultFolded !== undefined) {
+            block.folded = defaultFolded
+        }
+    }
+
+    onSearchTextChanged: {
+        applySearchToBlock(generalBlock, true)
+        applySearchToBlock(notificationsBlock, true)
+        applySearchToBlock(utilitiesBlock, true)
+        applySearchToBlock(privacyBlock, settingsPrivacyFolded)
+        applySearchToBlock(appsBlock, true)
+        applySearchToBlock(caBlock, unfoldSection != "CA")
+        applySearchToBlock(resourcesBlock, true)
+        applySearchToBlock(reportBlock, true)
+        applySearchToBlock(remoteNodeBlock, unfoldSection != "BEAM_NODE")
+        applySearchToBlock(nodeBlock, unfoldSection != "BEAM_NODE")
+        applySearchToBlock(ipfsBlock, unfoldSection != "IPFS_NODE")
+        applySearchToBlock(swapEthSettings, creating ? (unfoldSection == viewModel.ethSettings.coinID ? false : (unfoldSection == "ALL_COINS" ? viewModel.ethSettings.isConnected : true)) : viewModel.ethSettings.folded)
     }
 
     //% "Settings"
@@ -84,6 +163,28 @@ ColumnLayout {
         }
     }
 
+    SearchBox {
+        Layout.fillWidth: true
+        Layout.leftMargin: 20
+        Layout.rightMargin: 20
+        Layout.bottomMargin: 10
+        alwaysVisibleInput: true
+        //% "Search settings"
+        placeholderText: qsTrId("settings-search-placeholder")
+        onTextChanged: settingsView.searchText = text
+    }
+
+    SFText {
+        Layout.leftMargin: 20
+        Layout.rightMargin: 20
+        Layout.bottomMargin: 10
+        visible: settingsView.searchActive && !settingsView.hasSearchResults()
+        color: Style.content_secondary
+        font.pixelSize: 14
+        //% "No matching settings"
+        text: qsTrId("settings-search-no-results")
+    }
+
     ScrollView {
         Layout.fillHeight: true
         Layout.bottomMargin: 10
@@ -108,33 +209,51 @@ ColumnLayout {
                 SettingsGeneral {
                     id: generalBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(generalBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(generalBlock)
                 }
 
                 SettingsNotifications {
                     id: notificationsBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(notificationsBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(notificationsBlock)
                 }
 
                 SettingsUtilities {
                     id: utilitiesBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(utilitiesBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(utilitiesBlock)
                 }
 
                 SettingsPrivacy {
                     id: privacyBlock
                     viewModel: viewModel
                     folded: settingsPrivacyFolded
+                    visible: settingsView.blockMatches(privacyBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(privacyBlock)
                 }
 
                 SettingsApps {
                     id: appsBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(appsBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(appsBlock)
                 }
 
                 SettingsCA {
                     id: caBlock
                     viewModel: viewModel
                     folded: unfoldSection != "CA"
+                    visible: settingsView.blockMatches(caBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(caBlock)
                 }
 
                 SettingsTitle {
@@ -146,11 +265,17 @@ ColumnLayout {
                 SettingsResources {
                     id: resourcesBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(resourcesBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(resourcesBlock)
                 }
 
                 SettingsReport {
                     id: reportBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(reportBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(reportBlock)
                 }
             }
 
@@ -167,6 +292,9 @@ ColumnLayout {
                 SettingsBeamRemoteNode {
                     id: remoteNodeBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(remoteNodeBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(remoteNodeBlock)
 
                     showStatus: true
                     connectionStatus: getStatus()
@@ -184,6 +312,9 @@ ColumnLayout {
                 SettingsBeamNode {
                     id: nodeBlock
                     viewModel: viewModel
+                    visible: settingsView.blockMatches(nodeBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(nodeBlock)
 
                     showStatus: true
                     connectionStatus: getStatus()
@@ -201,7 +332,9 @@ ColumnLayout {
                 SettingsIPFS {
                     id: ipfsBlock
                     viewModel: viewModel
-                    visible: viewModel.ipfsSupported
+                    visible: viewModel.ipfsSupported && settingsView.blockMatches(ipfsBlock)
+                    searchActive: settingsView.searchActive
+                    searchMatched: settingsView.blockMatches(ipfsBlock)
                     folded: unfoldSection != "IPFS_NODE"
 
                     showStatus: true
@@ -232,6 +365,9 @@ ColumnLayout {
 
                         mainSettingsViewModel:    viewModel
                         showStatus:               true
+                        visible:                  settingsView.blockMatches(settingsControl)
+                        searchActive:             settingsView.searchActive
+                        searchMatched:            settingsView.blockMatches(settingsControl)
 
                         //
                         // Node
@@ -386,6 +522,9 @@ ColumnLayout {
                     mainSettingsViewModel:    viewModel
                     showStatus:               true
                     getEthereumAddresses:     viewModel.ethSettings.getEthereumAddresses
+                    visible:                  settingsView.blockMatches(swapEthSettings)
+                    searchActive:             settingsView.searchActive
+                    searchMatched:            settingsView.blockMatches(swapEthSettings)
                     folded:                   creating ? (unfoldSection == viewModel.ethSettings.coinID ? false : (unfoldSection == "ALL_COINS" ? viewModel.ethSettings.isConnected : true)) : viewModel.ethSettings.folded
                     canChangeConnection:      viewModel.ethSettings.canChangeConnection
                     isConnected:              viewModel.ethSettings.isConnected

--- a/ui/view/controls/SettingsFoldable.qml
+++ b/ui/view/controls/SettingsFoldable.qml
@@ -12,6 +12,8 @@ Control {
     property bool   folded: true
     property var    content: null
     spacing: 10
+    property bool   searchActive: false
+    property bool   searchMatched: false
 
     // Status indicator
     property bool   showStatus: false
@@ -135,7 +137,11 @@ Control {
 
     background: Rectangle {
         radius:  10
-        color:   Style.background_second
+        color:   control.searchActive && control.searchMatched
+                    ? Qt.rgba(Style.active.r, Style.active.g, Style.active.b, 0.12)
+                    : Style.background_second
+        border.color: control.searchActive && control.searchMatched ? Style.active : "transparent"
+        border.width: control.searchActive && control.searchMatched ? 1 : 0
 
         MouseArea {
             anchors.left: parent.left


### PR DESCRIPTION
Closes #824

Adds a Settings search box that filters settings sections by section title, visible parameter labels, and current displayed values.

Changes:
- Adds an always-visible search field at the top of Settings
- Filters Settings foldable blocks based on matching visible text/current values
- Expands matching sections while search is active
- Highlights matching sections with the active blue color
- Shows a no-results message
- Adds English and Korean translation entries

Validation:
- Ran `git diff --check`

Note: I could not run the full Qt/QML application build locally because the required Qt build tools are not installed in this environment.