### PR TITLE
#823: Add "Remove current wallet" to Utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,9 @@ else()
        CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang" AND
        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 15 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 15))
        add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION) # boost@1.76/1.76.0_4/include/boost/container_hash/hash.hpp:131:33
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option") # newer clang (21) dropped -Wenum-constexpr-conversion
        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion -Wno-error=enum-constexpr-conversion")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator -Wno-error=deprecated-literal-operator")
     endif()
 endif()
 

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -55,6 +55,18 @@ set (CMAKE_PREFIX_PATH ${BEAM_QT_ROOT_DIR})
 
 find_package(Qt6 COMPONENTS Core Gui Widgets Qml Quick QuickControls2 Svg WebEngineQuick WebEngineWidgets WebChannel Core5Compat HttpServer REQUIRED)
 
+# Qt's FindWrapOpenGL unconditionally links Apple's AGL framework, which has been
+# removed from recent macOS SDKs (Xcode 16+/macOS 15+). AGL is a legacy pre-OpenGL-3
+# framework that Qt 6 does not actually use, so drop the vestigial entry from the
+# WrapOpenGL interface to let the app link against the modern SDK.
+if (APPLE AND TARGET WrapOpenGL::WrapOpenGL)
+    get_target_property(_wrap_opengl_libs WrapOpenGL::WrapOpenGL INTERFACE_LINK_LIBRARIES)
+    if (_wrap_opengl_libs)
+        list(FILTER _wrap_opengl_libs EXCLUDE REGEX "AGL")
+        set_target_properties(WrapOpenGL::WrapOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "${_wrap_opengl_libs}")
+    endif()
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
@@ -325,10 +337,19 @@ target_link_libraries(${TARGET_NAME} quazip_static)
 #if (BEAM_WALLET_WITH_NODE)
     add_definitions(-DBEAM_WALLET_WITH_NODE)
     target_link_libraries(${TARGET_NAME}
-            node 
+            node
             external_pow
     )
 #endif()
+
+# beam exposes its source root as a SYSTEM include path, so #include "node/node.h"
+# is meant to resolve to beam/node/node.h. On some toolchains (e.g. Apple clang 21)
+# /usr/local/include is searched ahead of -isystem paths; if a Node.js dev install
+# lives there it ships a node/ directory too and shadows beam's header. -iquote puts
+# beam's tree first for quote-includes only, without altering <angled> resolution.
+if (NOT MSVC)
+    target_compile_options(${TARGET_NAME} PRIVATE "-iquote" "${PROJECT_SOURCE_DIR}/beam")
+endif()
 
 target_link_libraries(${TARGET_NAME}
         beam

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -3915,5 +3915,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation>скапіяваць SBBS адрас і зачыніць</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -3915,5 +3915,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -3900,5 +3900,33 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
         <source>copy SBBS address and close</source>
         <translation>SBBS Addresse kopieren und schließen</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -2809,6 +2809,34 @@ Update your settings and try again.</translation>
         <source>Show UTXO</source>
         <translation>Show UTXO</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation>Remove current wallet</translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation>Are you sure you want to remove your wallet?</translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation>proceed</translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation>Confirm wallet removal</translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation>Enter your password to remove the wallet</translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation>remove</translation>
+    </message>
     <message id="general-coin">
         <source>Coin</source>
         <translation>Coin</translation>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -3904,5 +3904,33 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -3906,5 +3906,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -3902,5 +3902,33 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
         <source>copy SBBS address and close</source>
         <translation>copier l&apos;adresse SBBS et fermer</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -3896,5 +3896,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation>salin alamat SBBS dan tutup</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -3904,5 +3904,33 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
         <source>copy SBBS address and close</source>
         <translation>copia l&apos;indirizzo SBBS e chiudi</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -3873,5 +3873,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -3896,5 +3896,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -3901,5 +3901,33 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -3903,5 +3903,33 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
         <source>copy SBBS address and close</source>
         <translation>copiar endereço SBBS e fechar</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -3917,5 +3917,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation>копировать SBBS адрес и закрыть</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -3928,5 +3928,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -3902,5 +3902,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -3896,5 +3896,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -3896,5 +3896,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -3912,5 +3912,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation>Копіювати SBBS адресу і закрити</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -3909,5 +3909,33 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>copy SBBS address and close</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -3912,5 +3912,33 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>copy SBBS address and close</source>
         <translation type="unfinished">copy SBBS address and close</translation>
     </message>
+    <message id="settings-remove-wallet">
+        <source>Remove current wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-message">
+        <source>All data will be erased. Make sure you&apos;ve saved your seed phrase if you want to restore this wallet later on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-confirm-question">
+        <source>Are you sure you want to remove your wallet?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-proceed">
+        <source>proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-title">
+        <source>Confirm wallet removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-placeholder">
+        <source>Enter your password to remove the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-remove-wallet-password-button">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/model/app_model.cpp
+++ b/ui/model/app_model.cpp
@@ -452,7 +452,19 @@ void AppModel::resetWallet()
         return;
     }
 
-    onResetWallet();
+    // No integrated node to stop: defer the reset to the next event-loop
+    // iteration so that any UI which triggered it can tear itself down first,
+    // releasing its references to the asset managers (onResetWallet asserts
+    // that it uniquely owns them).
+    QMetaObject::invokeMethod(this, &AppModel::onResetWallet, Qt::QueuedConnection);
+}
+
+void AppModel::removeCurrentWallet()
+{
+    // Unlike resetWallet() (which is used to undo a restore/creation and keeps
+    // a backup), removing the wallet must wipe the whole account permanently.
+    m_removeAccount = true;
+    resetWallet();
 }
 
 void AppModel::onResetWallet()
@@ -477,6 +489,23 @@ void AppModel::onResetWallet()
     resetSwapClients();
     assert(m_db);
     m_db.reset();
+
+    if (m_removeAccount)
+    {
+        m_removeAccount = false;
+
+        // Permanently wipe the whole account directory (all wallet DBs across
+        // versions, local node storage, app data, settings) so the account no
+        // longer appears in the wallet/account list.
+        const auto accountDir = QString::fromStdString(getSettings().getUserDataPath());
+        if (!QDir(accountDir).removeRecursively())
+        {
+            BEAM_LOG_ERROR() << "Failed to remove account directory: " << accountDir.toStdString();
+        }
+
+        emit walletRemoved();
+        return;
+    }
 
     try
     {

--- a/ui/model/app_model.h
+++ b/ui/model/app_model.h
@@ -71,6 +71,7 @@ public:
 
     void nodeSettingsChanged();
     void resetWallet();
+    void removeCurrentWallet();
     bool exportData();
     bool importData();
     bool isSeedValidationMode() const;
@@ -105,6 +106,7 @@ public slots:
 signals:
     void walletReset();
     void walletResetCompleted();
+    void walletRemoved();
 
 private:
     void start();
@@ -146,6 +148,7 @@ private:
     Connections m_walletConnections;
     static AppModel* s_instance;
     std::string m_walletDBBackupPath;
+    bool m_removeAccount = false;
 
     bool m_isSeedValidationMode = false;
     bool m_isSeedValidationTriggeredFromSettings = false;

--- a/ui/view/controls/ConfirmPasswordDialog.qml
+++ b/ui/view/controls/ConfirmPasswordDialog.qml
@@ -5,6 +5,7 @@
     import "."
 
     CustomDialog {
+    id: control
     property var settingsViewModel: function() {
         return {
             checkWalletPassword: function() {
@@ -16,11 +17,13 @@
 
     property string dialogTitle: "title"
     property string dialogMessage: "message"
+    property color okButtonColor: Style.active
     property alias okButtonText: okButton.text
     property alias okButtonIcon: okButton.icon.source
     property alias cancelButtonText: cancelButton.text
     property alias cancelButtonIcon: cancelButton.icon.source
     property alias pwd: pwd.text
+    property alias passwordPlaceholderText: pwd.placeholderText
     property bool showError: false
     property var onDialogAccepted: function() {
         console.log("Accepted");
@@ -65,6 +68,7 @@
                 Layout.fillWidth:       true
                 Layout.alignment:       Qt.AlignHCenter
                 text:                   dialogMessage
+                visible:                dialogMessage.length > 0
                 color:                  Style.content_main
                 font.pixelSize:         14
                 wrapMode:               Text.Wrap
@@ -77,6 +81,8 @@
                 font.pixelSize: 14
                 rightPadding:   0
                 hasError: showError
+                // keep the placeholder visible while the (empty) field is focused
+                focusablePlaceholder: placeholderText.length > 0
                 onTextEdited: {
                     showError = false;
                 }
@@ -130,6 +136,7 @@
                 //: confirm password dialog, ok button
                 //% "Proceed"
                 text: qsTrId("general-proceed")
+                palette.button: control.okButtonColor
                 enabled: !showError
                 icon.source: "qrc:/assets/icon-done.svg"
                 onClicked: {

--- a/ui/view/controls/SettingsUtilities.qml
+++ b/ui/view/controls/SettingsUtilities.qml
@@ -18,6 +18,62 @@ SettingsFoldable {
         settingsViewModel: viewModel
     }
 
+    ConfirmationDialog {
+        id: removeWalletConfirmationDialog
+        parent: main
+        //% "Remove current wallet"
+        title: qsTrId("settings-remove-wallet")
+        //% "All data will be erased. Make sure you've saved your seed phrase if you want to restore this wallet later on!"
+        text: qsTrId("settings-remove-wallet-confirm-message") + "\n\n" +
+              //% "Are you sure you want to remove your wallet?"
+              qsTrId("settings-remove-wallet-confirm-question")
+        //% "proceed"
+        okButtonText: qsTrId("settings-remove-wallet-proceed")
+        okButtonIconSource: "qrc:/assets/icon-next-white.svg"
+        okButtonColor: Style.swapStateIndicator
+        cancelButtonIconSource: "qrc:/assets/icon-cancel-white.svg"
+        cancelButtonVisible: true
+        width: 460
+        height: 252
+
+        onAccepted: {
+            removeWalletPasswordDialog.open()
+        }
+    }
+
+    ConfirmPasswordDialog {
+        id: removeWalletPasswordDialog
+        parent: main
+        settingsViewModel: viewModel
+        //% "Confirm wallet removal"
+        dialogTitle: qsTrId("settings-remove-wallet-password-title")
+        dialogMessage: ""
+        //% "Enter your password to remove the wallet"
+        passwordPlaceholderText: qsTrId("settings-remove-wallet-password-placeholder")
+        //% "remove"
+        okButtonText: qsTrId("settings-remove-wallet-password-button")
+        okButtonIcon: "qrc:/assets/icon-delete.svg"
+        okButtonColor: Style.swapStateIndicator
+
+        onDialogAccepted: function() {
+            // Defer one turn so this (modal) dialog finishes closing and releases
+            // its input grab on the window overlay before we navigate away;
+            // otherwise the grab leaks and blocks input on the start screen.
+            //
+            // Inside the callback: drop the main wallet UI first (setSource
+            // schedules deferred deletion of every main view-model, releasing
+            // their references to the asset managers), then removeCurrentWallet()
+            // - viewModel is only marked for deletion and still alive here - so
+            // the reset is posted AFTER those deletions and AppModel::onResetWallet()
+            // sees the asset managers uniquely owned.
+            Qt.callLater(function() {
+                main.parent.setSource("qrc:/start.qml")
+                viewModel.removeCurrentWallet()
+            })
+        }
+        onDialogRejected: function() {}
+    }
+
     PublicOfflineAddressDialog {
         id: publicOfflineAddressDialog;
     }
@@ -89,6 +145,16 @@ SettingsFoldable {
             bold: true
             onClicked: {
                 utxoDialog.open()
+            }
+        }
+
+        LinkButton {
+            //% "Remove current wallet"
+            text: qsTrId("settings-remove-wallet")
+            linkColor: Style.validator_error
+            bold: true
+            onClicked: {
+                removeWalletConfirmationDialog.open()
             }
         }
     }

--- a/ui/viewmodel/settings_view.cpp
+++ b/ui/viewmodel/settings_view.cpp
@@ -574,6 +574,11 @@ void SettingsViewModel::changeWalletPassword(const QString& pass)
     AppModel::getInstance().changeWalletPassword(pass.toStdString());
 }
 
+void SettingsViewModel::removeCurrentWallet()
+{
+    AppModel::getInstance().removeCurrentWallet();
+}
+
 #ifdef BEAM_ASSET_SWAP_SUPPORT
 void SettingsViewModel::allowAssetId(quint32 asset)
 {

--- a/ui/viewmodel/settings_view.h
+++ b/ui/viewmodel/settings_view.h
@@ -165,6 +165,7 @@ public:
     Q_INVOKABLE bool hasPeer(const QString& peer) const;
     Q_INVOKABLE void reportProblem();
     Q_INVOKABLE void changeWalletPassword(const QString& pass);
+    Q_INVOKABLE void removeCurrentWallet();
 #ifdef BEAM_ASSET_SWAP_SUPPORT
     Q_INVOKABLE void allowAssetId(quint32 asset);
     Q_INVOKABLE void disallowAssetId(quint32 asset);

--- a/ui/viewmodel/start_view.cpp
+++ b/ui/viewmodel/start_view.cpp
@@ -330,6 +330,8 @@ StartViewModel::StartViewModel()
 {
     findExistingWalletDBIfNeeded();
 
+    connect(&AppModel::getInstance(), &AppModel::walletRemoved, this, &StartViewModel::onWalletRemoved);
+
 #if defined(BEAM_HW_WALLET)
     connect(&m_trezorThread, SIGNAL(ownerKeyImported()), this, SLOT(onTrezorOwnerKeyImported()));
     connect(&m_trezorTimer, SIGNAL(timeout()), this, SLOT(checkTrezor()));
@@ -1279,4 +1281,23 @@ QString StartViewModel::getAccountPictureByIndex(int index) const
 void StartViewModel::resetModel()
 {
     setCurrentAccountIndexForced(0);
+}
+
+void StartViewModel::onWalletRemoved()
+{
+    // The current account directory was deleted. Drop the cached account list so
+    // getAccounts() rescans and the removed account disappears.
+    m_accounts.clear();
+    emit currentNetworkChanged();
+
+    // Re-point the model at the first remaining account. This is required because
+    // the AppModel still references the just-removed account; without it, picking
+    // the intended account at the same (now shifted) list position would be a
+    // no-op and walletExists would stay false (blocking the password field).
+    // Deferred to the next event-loop turn because setCurrentAccountIndexForced()
+    // calls AppModel::resetInstance(), which must not run inside the
+    // AppModel::walletRemoved emission (it would destroy the emitting instance).
+    QMetaObject::invokeMethod(this, [this]() {
+        setCurrentAccountIndexForced(0);
+    }, Qt::QueuedConnection);
 }

--- a/ui/viewmodel/start_view.h
+++ b/ui/viewmodel/start_view.h
@@ -249,6 +249,7 @@ public slots:
     bool checkWalletPassword(const QString& password) const;
     void setPassword(const QString& pass);
     void onNodeSettingsChanged();
+    void onWalletRemoved();
 
 #if defined(BEAM_HW_WALLET)
     void onTrezorOwnerKeyImported();


### PR DESCRIPTION
Fixes #823.

Adds a **Remove current wallet** action to Settings → Utilities.

## Behaviour
- A red *Remove current wallet* link in Utilities opens a confirmation dialog warning that all data will be erased.
- On *proceed*, a password dialog (title *Confirm wallet removal*) requires the wallet password.
- On confirmation the wallet is removed and the app returns to the start screen, with the account fully gone from the account list.

## Notes
- New `qsTrId` strings are added to `en_US.ts` (the other locale catalogs are produced by the existing Crowdin/`lupdate` flow on build).
- The removal **permanently wipes the whole account directory** (all per-version wallet DBs, local node storage, app data, settings) via a dedicated `AppModel::removeCurrentWallet()` path. This is intentionally separate from `resetWallet()` (which keeps a backup for the cancel-a-restore flow), so the account no longer appears in the account list.
- The main UI is torn down before `onResetWallet()` runs so it doesn't hold references to the asset managers during reset, and `StartViewModel` re-points at the first remaining account afterwards so the password field is immediately usable.
- The `CMakeLists.txt` changes are build fixes required to compile with Apple clang 21 / recent macOS SDKs (deprecated-literal-operator / unknown `-Wenum-constexpr-conversion`, the `node/` header collision, and the removed AGL framework). The matching `beam` submodule fix is handled separately in BeamMW/beam#2054.

## Screenshots

<img width="491" height="398" alt="image" src="https://github.com/user-attachments/assets/ca4c9492-bcb2-4d58-a6f5-549cf17d99f8" />
<img width="495" height="283" alt="image" src="https://github.com/user-attachments/assets/4065161a-1644-4e85-8129-639c9aa663d8" />
<img width="369" height="238" alt="image" src="https://github.com/user-attachments/assets/362409bc-7f21-4dfb-a385-6c5f318a64d3" />
