### PR TITLE
fix(#1195 #1247): Reload dapps only when local apps list changes

### DIFF
--- a/ui/viewmodel/applications/apps_view.cpp
+++ b/ui/viewmodel/applications/apps_view.cpp
@@ -643,10 +643,11 @@ namespace beamui::applications
             }
         }
 
-        _localApps = result;
-
-        //if (!_runApp)
+        if (_localApps != result)
+        {
+            _localApps = result;
             emit appsChanged();
+        }
     }
 
     void AppsViewModel::loadDevApps()


### PR DESCRIPTION
## Problem

The Applications grid reloads on every synced block: the **ALL** tab scrolls back to top every few seconds and dapp SVG icons reload continuously (#1247), driven by the same mechanism reported in #1195.

## Root cause

`loadApps()` is connected to `WalletModel::walletStatusChanged`, which fires on every synced block. Inside it, `loadLocalApps()` called `emit appsChanged()` **unconditionally** every time (the original guard was commented out). That signal makes QML reassign the apps model and run `m_appsModel.reset()`, which destroys and recreates every `GridView` delegate — resetting scroll position and reloading every icon.

The other three loaders (`loadDevApps`, `loadDefaultApps`, `loadAppsFromStore`) already guard their emit with an "only if the list changed" check; `loadLocalApps` was the odd one out.

## Fix

Guard `loadLocalApps()`'s emit the same way — only emit `appsChanged()` when `_localApps` actually changes. Routine per-block status ticks no longer reset the model, so the grid keeps its scroll position and loaded icons, while genuine install/remove/update still refresh the UI.

We intentionally keep `loadApps()` running on every `walletStatusChanged` so followed-publisher updates are picked up promptly; reducing the per-block work is left as a separate follow-up.

Fixes #1195, #1247