### PR TITLE
#1098 Add confirmation window when deleting a contact

### DIFF
--- a/ui/view/addresses.qml
+++ b/ui/view/addresses.qml
@@ -286,6 +286,7 @@ ColumnLayout {
                             {
                                 contextMenu.walletID = contactsView.model[styleData.row].walletID;
                                 contextMenu.token = contactsView.model[styleData.row].token;
+                                contextMenu.name = contactsView.model[styleData.row].name;
                                 contextMenu.popup();
                             }
                         }
@@ -322,6 +323,7 @@ ColumnLayout {
                                     onClicked: {
                                         contextMenu.walletID = contactsView.model[styleData.row].walletID;
                                         contextMenu.token = contactsView.model[styleData.row].token;
+                                        contextMenu.name = contactsView.model[styleData.row].name;
                                         contextMenu.popup(contactActionsButton, contactActionsButton.width - contextMenu.implicitWidth, contactActionsButton.height);
                                     }
                                 }
@@ -336,6 +338,7 @@ ColumnLayout {
                     dim: false
                     property string walletID
                     property string token
+                    property string name
                     Action {
                         //% "Send"
                         text: qsTrId("general-send")
@@ -349,7 +352,14 @@ ColumnLayout {
                         text: qsTrId("address-table-cm-delete-contact")
                         icon.source: "qrc:/assets/icon-delete.svg"
                         onTriggered: {
-                            viewModel.deleteAddress(contextMenu.token);
+                            var dialog = Qt.createComponent("controls/DeleteAddress.qml").createObject(main, {
+                                viewModel:           viewModel,
+                                addressItem:         { "token": contextMenu.token, "walletID": contextMenu.walletID, "name": contextMenu.name },
+                                isShieldedSupported: control.isShieldedSupported,
+                                //% "Delete contact"
+                                dialogTitle:         qsTrId("address-table-cm-delete-contact")
+                            })
+                            dialog.open();
                         }
                     }
                 }

--- a/ui/view/controls/DeleteAddress.qml
+++ b/ui/view/controls/DeleteAddress.qml
@@ -16,6 +16,11 @@ CustomDialog {
     property var  addressItem
     property bool isShieldedSupported: true
 
+    //% "Delete address"
+    property string dialogTitle: qsTrId("address-table-cm-delete")
+
+    property string name:          (addressItem && addressItem.name) ? addressItem.name : ""
+
     property var     token:         addressItem.token
     property var     walletID:      addressItem.walletID
     property var     isOldAddr:     addressItem.token == addressItem.walletID
@@ -26,11 +31,23 @@ CustomDialog {
         SFText {
             Layout.alignment: Qt.AlignHCenter
 
-            //% "Delete address"
-            text:           qsTrId("address-table-cm-delete")
+            text:           control.dialogTitle
             color:          Style.content_main
             font.pixelSize: 18
             font.weight:    Font.Bold
+        }
+
+        SFText {
+            Layout.alignment:      Qt.AlignHCenter
+            Layout.topMargin:      10
+            Layout.preferredWidth: control.isOldAddr ? 510: 582
+            visible:               control.name.length > 0
+            horizontalAlignment:   Text.AlignHCenter
+            wrapMode:              Text.Wrap
+            text:                  control.name
+            color:                 Style.content_main
+            font.pixelSize:        14
+            font.weight:           Font.Bold
         }
 
         ScrollView {
@@ -84,7 +101,7 @@ CustomDialog {
                 text: qsTrId("general-delete")
                 icon.source: "qrc:/assets/icon-done.svg"
                 onClicked: {
-                viewModel.deleteAddress(contextMenu.addressItem.token)
+                viewModel.deleteAddress(control.token)
                 control.destroy()
                 }
             }


### PR DESCRIPTION
Closes #1098 (same pattern as #1083).

## Problem
Deleting a contact (Address Book → Contacts → Actions → Delete contact) removed it immediately with no confirmation, unlike addresses which already show a confirmation dialog.

## Change
- Reuse the existing `DeleteAddress.qml` dialog for the contacts delete action instead of deleting directly.
- Make `DeleteAddress.qml` reusable: configurable `dialogTitle` ("Delete address" vs "Delete contact") and a robust delete handler (`control.token` instead of reaching into a global `contextMenu`).
- Show the address/contact **name** in the dialog (hidden when empty) for extra clarity. Addresses get it automatically from `AddressItem`; contacts pass it through the context menu.

All strings reuse existing i18n ids — no `.ts` additions.

## Test
- Contacts: named and unnamed contact → confirmation dialog appears with the correct title/name, Cancel aborts, Delete removes.
- Addresses: Delete still works and now shows the address name.