### PR TITLE
#1065 Show in-progress transaction count on the Transactions tab

### DIFF
--- a/ui/view/applications/applications.qml
+++ b/ui/view/applications/applications.qml
@@ -318,7 +318,10 @@ ColumnLayout {
 
             TabButton {
                 id: txTab
-                label:              qsTrId("wallet-transactions-title")
+                label:              qsTrId("wallet-transactions-title") +
+                                    (txTable.activeTxCnt > 0
+                                        ? " " + qsTrId("apps-inprogress-tip").arg(txTable.activeTxCnt)
+                                        : "")
                 Layout.alignment:   Qt.AlignVCenter
                 onClicked:          appsRoot.state = "transactions"
             }


### PR DESCRIPTION
Closes #1065.

## Problem
Since the transaction list moved into a second tab on the main window, there's no indication that transactions are in progress unless you switch to that tab.

## Change
Append the active-transaction count to the **Transactions** tab label on the main window, e.g. `Transactions (1 active)` — the same pattern already used by the DApps panel. The indicator is visible while on the Applications tab too, so in-progress transactions are noticeable without navigating.

Reuses existing infrastructure — no new C++ or i18n strings:
- `txTable.activeTxCnt` (already computed in the same view, same value DApps uses)
- `apps-inprogress-tip` = `(%1 active)` (existing string)

When no transactions are active, the label is just `Transactions`.

## Test
- Start a transaction → tab reads `Transactions (1 active)` (count updates with the number of active txs).
- No active transactions → label is plain `Transactions`.