### PR TITLE
Fix Qt6 rendering regressions in messenger, notifications and icons

### DIFF
--- a/ui/view/beam_chat.qml
+++ b/ui/view/beam_chat.qml
@@ -93,12 +93,6 @@ ColumnLayout {
                 receiverAddrDialog.peerAddr = thisView.receiverAddr;
                 receiverAddrDialog.open();
             }
-
-            ColorOverlay {
-                anchors.fill: parent
-                source: parent
-                color: Style.content_main
-            }
         }
 
         CustomToolButton {
@@ -154,34 +148,40 @@ ColumnLayout {
                         visible: !is_income
                     }
 
-                    ColumnLayout {
-                        Layout.alignment: is_income ? Qt.AlignLeft : Qt.AlignRight
-                        spacing: 0
-                        Layout.margins: 4
-
-                        SFText {
-                            Layout.margins: 7
-                            text: time
-                            font.pixelSize: 12
-                            color: Style.content_secondary
-                        }
-                        SFText {
-                            Layout.margins: 7
-                            Layout.topMargin: 0
-                            Layout.maximumWidth: scrollView.width - 70
-                            text: message
-                            textFormat: Text.PlainText
-                            wrapMode: Text.Wrap
-                            font.pixelSize: 16
-                            color: Style.content_main
-                        }
+                    Item {
+                        Layout.alignment:    is_income ? Qt.AlignLeft : Qt.AlignRight
+                        Layout.margins:      4
+                        implicitWidth:       bubbleContent.implicitWidth
+                        implicitHeight:      bubbleContent.implicitHeight
 
                         Rectangle {
-                            width: parent.width
-                            height: parent.height
+                            anchors.fill: parent
                             radius:       10
                             color:        is_income ? Style.accent_incoming : Style.accent_outgoing
                             opacity:      0.5
+                        }
+
+                        ColumnLayout {
+                            id: bubbleContent
+                            anchors.fill: parent
+                            spacing: 0
+
+                            SFText {
+                                Layout.margins: 7
+                                text: time
+                                font.pixelSize: 12
+                                color: Style.content_secondary
+                            }
+                            SFText {
+                                Layout.margins: 7
+                                Layout.topMargin: 0
+                                Layout.maximumWidth: scrollView.width - 70
+                                text: message
+                                textFormat: Text.PlainText
+                                wrapMode: Text.Wrap
+                                font.pixelSize: 16
+                                color: Style.content_main
+                            }
                         }
                     }
 

--- a/ui/view/beam_messenger.qml
+++ b/ui/view/beam_messenger.qml
@@ -83,15 +83,46 @@ ColumnLayout {
                 opacity:      hoverArea.containsMouse ? 0.15 : 0.1
             }
 
+            // Accent strip on the left edge, clipped to the pill's rounded
+            // shape so its ends follow the corner curve instead of overhanging.
+            Item {
+                anchors.fill: parent
+                visible:      haveUnread
+
+                Item {
+                    id: accentSource
+                    anchors.fill: parent
+                    visible:      false
+                    Rectangle {
+                        anchors.left:   parent.left
+                        anchors.top:    parent.top
+                        anchors.bottom: parent.bottom
+                        width:          5
+                        color:          Style.active
+                    }
+                }
+
+                Rectangle {
+                    id: pillMask
+                    anchors.fill: parent
+                    radius:       10
+                    visible:      false
+                }
+
+                OpacityMask {
+                    anchors.fill: parent
+                    source:       accentSource
+                    maskSource:   pillMask
+                }
+            }
+
             ColumnLayout {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.alignment: Qt.AlignVCenter
+                anchors.fill:     parent
+                anchors.leftMargin: 25
+                anchors.topMargin:  15
                 spacing: 7
 
                 SFText {
-                    Layout.topMargin: 15
-                    Layout.leftMargin: 25
                     text: name
                     font {
                         styleName:  "DemiBold"
@@ -103,32 +134,13 @@ ColumnLayout {
                 }
 
                 SFText {
-                    Layout.leftMargin: 25
                     text: cid
                     font.pixelSize: 14
                     color: Style.content_secondary
                     wrapMode: Text.Wrap
                 }
 
-                Item {
-                    Rectangle {
-                        id: not_read_indicator
-                        y: 6
-                        width: 4
-                        height: 64
-                        color: Style.active
-                    }
-
-                    DropShadow {
-                        anchors.fill: not_read_indicator
-                        radius: 5
-                        samples: 9
-                        color: Style.active
-                        source: not_read_indicator
-                    }
-
-                    visible: haveUnread
-                }
+                Item { Layout.fillHeight: true }
             }
 
             MouseArea {

--- a/ui/view/controls/SecurityNote.qml
+++ b/ui/view/controls/SecurityNote.qml
@@ -12,11 +12,13 @@ ColumnLayout {
 
     Item {
         Layout.fillWidth: true
+        Layout.preferredHeight:76
         Layout.maximumHeight:76
         Layout.minimumHeight:76
         SvgImage {
             id: icon
             anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
         }
         DropShadow {
             anchors.fill: icon

--- a/ui/view/controls/SvgImage.qml
+++ b/ui/view/controls/SvgImage.qml
@@ -1,15 +1,14 @@
 import QtQuick
-import QtQuick.Window
 
 Image {
     id: root
 
-    property real dpr: (Screen.devicePixelRatio == 1.0 ? 2 : Screen.devicePixelRatio)
+    // Display at the SVG's logical size, but render at device-pixel
+    // resolution (sourceSize) so it stays crisp on HiDPI screens.
+    sourceSize: originalSizeImage.sourceSize
 
-    sourceSize: Qt.size(originalSizeImage.sourceSize.width * dpr, originalSizeImage.sourceSize.height * dpr)
-
-    width:  originalSizeImage.sourceSize.width
-    height: originalSizeImage.sourceSize.height
+    width:  originalSizeImage.implicitWidth
+    height: originalSizeImage.implicitHeight
     smooth: true
 
     Image {

--- a/ui/view/notifications.qml
+++ b/ui/view/notifications.qml
@@ -153,9 +153,11 @@ ColumnLayout {
                 SvgImage {
                     anchors.left: parent.left
                     anchors.leftMargin: 30
-                    anchors.verticalCenter: parent.verticalCenter 
-        
+                    anchors.verticalCenter: parent.verticalCenter
+
                     source: getIconSource(type)
+                    width:  60
+                    height: 60
                 }
         
                 ColumnLayout {


### PR DESCRIPTION
Fixes a set of visual regressions introduced by the Qt6 migration (#1220). That migration only changed imports, so these are Qt6 runtime behaviour changes in unchanged code.

## Fixes

- **Oversized icons (all screens)** — Qt6 reports `Image.sourceSize` in device pixels (2x on HiDPI), and `SvgImage` used that for `width`/`height`, doubling every intrinsically-sized icon. Now uses the logical `implicitWidth`/`implicitHeight` for display while keeping device-pixel `sourceSize` for crisp rendering. Fixes the create-wallet seed icons, notifications, etc.
- **Beam Messenger – edit pencil rendered as a white square** — removed a redundant `ColorOverlay { source: parent }` (the `CustomToolButton` already tints via `icon.color`); in Qt6 the overlay filled the whole button white.
- **Beam Messenger – chat bubbles missing** — the bubble `Rectangle` was a mis-sized `ColumnLayout` sibling after the text; restructured so it sits behind the text as a background.
- **Beam Messenger – unread accent strip** — anchored to the row and masked to the pill's rounded shape so it follows the corner curve instead of overhanging the card.
- **Notifications – icon too small** — the per-row icon had no size and fell back to its 40px natural size; set to the design's 60px slot (matching the empty-state icon).
- **Create-wallet – icon/caption overlap** — gave the `SecurityNote` icon row a definite height so the icon no longer collapses into the caption.

## Test
Visually verified on macOS / Qt 6.8.3 (HiDPI): Beam Messenger chat list + conversation, Notifications, and the create-new-wallet screen.