### PR TITLE
#1058: Add language selector to start / onboarding screens

### DIFF
--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -415,7 +415,7 @@
     </message>
     <message id="start-migration-message">
         <source>Your wallet will be migrated to v</source>
-        <translation>Ihre Wallet wird nach v. migriert </translation>
+        <translation>Ihre Wallet wird migriert auf v</translation>
     </message>
     <message id="start-migration-button">
         <source>start auto migration</source>

--- a/ui/view/controls/LanguageComboBox.qml
+++ b/ui/view/controls/LanguageComboBox.qml
@@ -1,0 +1,18 @@
+import QtQuick
+import QtQuick.Controls
+import "."
+
+CustomComboBox {
+    id: control
+
+    property var languages: []
+    property int languageIndex: 0
+    signal languageActivated(string language)
+
+    fontPixelSize: 14
+    enableScroll:  true
+
+    model:        languages
+    currentIndex: languageIndex
+    onActivated:  control.languageActivated(currentText)
+}

--- a/ui/view/controls/SettingsGeneral.qml
+++ b/ui/view/controls/SettingsGeneral.qml
@@ -36,7 +36,7 @@ SettingsFoldable {
                     Layout.preferredWidth: secondCurrencySwitch.width
                     languages:     viewModel.supportedLanguages
                     languageIndex: viewModel.currentLanguageIndex
-                    onLanguageActivated: viewModel.currentLanguage = language
+                    onLanguageActivated: (language) => { viewModel.currentLanguage = language }
                 }
             }
             //visible: false  // Remove to enable language dropdown

--- a/ui/view/controls/SettingsGeneral.qml
+++ b/ui/view/controls/SettingsGeneral.qml
@@ -31,17 +31,12 @@ SettingsFoldable {
             }
 
             ColumnLayout {
-                CustomComboBox {
+                LanguageComboBox {
                     id: language
                     Layout.preferredWidth: secondCurrencySwitch.width
-                    fontPixelSize: 14
-                    enableScroll: true
-
-                    model: viewModel.supportedLanguages
-                    currentIndex: viewModel.currentLanguageIndex
-                    onActivated: {
-                        viewModel.currentLanguage = currentText;
-                    }
+                    languages:     viewModel.supportedLanguages
+                    languageIndex: viewModel.currentLanguageIndex
+                    onLanguageActivated: viewModel.currentLanguage = language
                 }
             }
             //visible: false  // Remove to enable language dropdown

--- a/ui/view/qml.qrc
+++ b/ui/view/qml.qrc
@@ -72,6 +72,7 @@
         <file>controls/SettingsFoldable.qml</file>
         <file>controls/SettingsCA.qml</file>
         <file>controls/SettingsGeneral.qml</file>
+        <file>controls/LanguageComboBox.qml</file>
         <file>controls/SettingsNotifications.qml</file>
         <file>controls/SettingsUtilities.qml</file>
         <file>controls/SettingsPrivacy.qml</file>

--- a/ui/view/start_wizzard/OpenWalletPage.qml
+++ b/ui/view/start_wizzard/OpenWalletPage.qml
@@ -11,6 +11,12 @@ StartLayout {
     id:    startLayout
     property Item defaultFocusItem: openPassword
 
+    // optional leading button (e.g. "Back" during DB migration); driven by push() initial properties
+    property bool   firstButtonVisible: false
+    property string firstButtonText:    ""
+    property string firstButtonIcon:    ""
+    property var    firstButtonAction:   function() {}
+
     // default methods for open wallet, can be changed for unlock wallet
     property var openWallet: function (pass, callback) {
         viewModel.openWallet(pass, callback);
@@ -161,6 +167,14 @@ StartLayout {
                         }
                     })
                 }
+            }
+
+            CustomButton {
+                anchors.verticalCenter: parent.verticalCenter
+                visible:     startLayout.firstButtonVisible
+                text:        startLayout.firstButtonText
+                icon.source: startLayout.firstButtonIcon
+                onClicked:   startLayout.firstButtonAction()
             }
 
             PrimaryButton {

--- a/ui/view/start_wizzard/StartLayout.qml
+++ b/ui/view/start_wizzard/StartLayout.qml
@@ -13,6 +13,7 @@ Rectangle {
     color: Style.background_main
     default property alias content:     contentLayout.data
     property alias showNetworkSelector: networkSelector.visible
+    property alias showLanguageSelector: languageSelector.visible
 
     Image {
         fillMode: Image.PreserveAspectCrop
@@ -51,12 +52,23 @@ Rectangle {
         }
     }
 
+    LanguageComboBox {
+        id:                  languageSelector
+        anchors.right:       parent.right
+        anchors.top:         parent.top
+        anchors.rightMargin: 40
+        anchors.topMargin:   40
+        languages:           viewModel.supportedLanguages
+        languageIndex:       viewModel.currentLanguageIndex
+        onLanguageActivated: viewModel.currentLanguage = language
+    }
+
     VersionFooter {
-        id:                     version
-        anchors.right:          parent.right
-        anchors.top:            parent.top
-        anchors.rightMargin:    40
-        anchors.topMargin:      40
+        id:                  version
+        anchors.right:       parent.right
+        anchors.top:         languageSelector.bottom
+        anchors.rightMargin: 40
+        anchors.topMargin:   12
     }
 
     CustomComboBox {

--- a/ui/view/start_wizzard/StartLayout.qml
+++ b/ui/view/start_wizzard/StartLayout.qml
@@ -60,7 +60,7 @@ Rectangle {
         anchors.topMargin:   40
         languages:           viewModel.supportedLanguages
         languageIndex:       viewModel.currentLanguageIndex
-        onLanguageActivated: viewModel.currentLanguage = language
+        onLanguageActivated: (language) => { viewModel.currentLanguage = language }
     }
 
     VersionFooter {

--- a/ui/view/start_wizzard/WizzardPage.qml
+++ b/ui/view/start_wizzard/WizzardPage.qml
@@ -46,10 +46,21 @@ Item {
             Layout.maximumHeight: 143
         }
     }
-    VersionFooter {
-        anchors.right: parent.right
-        anchors.top: parent.top
+    LanguageComboBox {
+        id:                  languageSelector
+        anchors.right:       parent.right
+        anchors.top:         parent.top
         anchors.rightMargin: 40
-        anchors.topMargin: 40
+        anchors.topMargin:   40
+        languages:           viewModel.supportedLanguages
+        languageIndex:       viewModel.currentLanguageIndex
+        onLanguageActivated: viewModel.currentLanguage = language
+    }
+
+    VersionFooter {
+        anchors.right:       parent.right
+        anchors.top:         languageSelector.bottom
+        anchors.rightMargin: 40
+        anchors.topMargin:   12
     }
 }

--- a/ui/view/start_wizzard/WizzardPage.qml
+++ b/ui/view/start_wizzard/WizzardPage.qml
@@ -54,7 +54,7 @@ Item {
         anchors.topMargin:   40
         languages:           viewModel.supportedLanguages
         languageIndex:       viewModel.currentLanguageIndex
-        onLanguageActivated: viewModel.currentLanguage = language
+        onLanguageActivated: (language) => { viewModel.currentLanguage = language }
     }
 
     VersionFooter {

--- a/ui/viewmodel/start_view.cpp
+++ b/ui/viewmodel/start_view.cpp
@@ -26,6 +26,7 @@
 #include "settings_view.h"
 #include "applications/apps_view.h"
 #include "model/app_model.h"
+#include "model/settings.h"
 #include "model/keyboard.h"
 #include "version.h"
 #include "wallet/core/secstring.h"
@@ -1158,6 +1159,31 @@ void StartViewModel::setCurrentNetwork(const QString& network)
 int StartViewModel::getCurrentNetworkIndex() const
 {
     return (int)Rules::get().m_Network;
+}
+
+QStringList StartViewModel::getSupportedLanguages() const
+{
+    return WalletSettings::getSupportedLanguages();
+}
+
+QString StartViewModel::getCurrentLanguage() const
+{
+    return AppModel::getInstance().getSettings().getLanguageName();
+}
+
+void StartViewModel::setCurrentLanguage(const QString& value)
+{
+    auto& settings = AppModel::getInstance().getSettings();
+    if (settings.getLanguageName() == value)
+        return;
+
+    settings.setLocaleByLanguageName(value);   // emits localeChanged -> Translator retranslates
+    emit currentLanguageChanged();             // refreshes currentLanguageIndex binding
+}
+
+int StartViewModel::getCurrentLanguageIndex() const
+{
+    return getSupportedLanguages().indexOf(getCurrentLanguage());
 }
 
 const QList<QVariantMap>& StartViewModel::getAccounts() const

--- a/ui/viewmodel/start_view.h
+++ b/ui/viewmodel/start_view.h
@@ -21,6 +21,7 @@
 #include <QThread>
 #include <QJSValue>
 #include <QDir>
+#include <QStringList>
 #include "wallet/core/wallet_db.h"
 #include "mnemonic/mnemonic.h"
 #include "messages_view.h"
@@ -145,6 +146,9 @@ class StartViewModel : public QObject
     Q_PROPERTY(QList<QVariantMap> networks READ getNetworks CONSTANT)
     Q_PROPERTY(QString currentNetwork READ getCurrentNetwork WRITE setCurrentNetwork NOTIFY currentNetworkChanged)
     Q_PROPERTY(int currentNetworkIndex READ getCurrentNetworkIndex NOTIFY currentNetworkChanged)
+    Q_PROPERTY(QStringList  supportedLanguages   READ getSupportedLanguages   CONSTANT)
+    Q_PROPERTY(QString      currentLanguage      READ getCurrentLanguage      WRITE setCurrentLanguage NOTIFY currentLanguageChanged)
+    Q_PROPERTY(int          currentLanguageIndex READ getCurrentLanguageIndex NOTIFY currentLanguageChanged)
     Q_PROPERTY(QList<QVariantMap> accounts READ getAccounts NOTIFY currentNetworkChanged)
     Q_PROPERTY(int currentAccountIndex READ getCurrentAccountIndex WRITE setCurrentAccountIndex NOTIFY currentAccountChanged)
     Q_PROPERTY(bool accountLabelExists READ getAccountLabelExists WRITE setAccountLabelExists NOTIFY accountLabelExistsChanged)
@@ -181,6 +185,10 @@ public:
     const QList<QObject*>& getWalletDBpaths();
     QList<QVariantMap> getNetworks() const;
     int getCurrentNetworkIndex() const;
+    QStringList getSupportedLanguages() const;
+    QString getCurrentLanguage() const;
+    void setCurrentLanguage(const QString& value);
+    int getCurrentLanguageIndex() const;
     bool isCapsLockOn() const;
     bool getValidateDictionary() const;
     void setValidateDictionary(bool value);
@@ -233,6 +241,7 @@ signals:
     void isUseHWWalletChanged();
     void saveSeedChanged();
     void currentNetworkChanged();
+    void currentLanguageChanged();
     void currentAccountChanged();
     void newAccountLabelChanged();
     void accountLabelExistsChanged();


### PR DESCRIPTION
Closes #1058.

Adds a language selector to the start / onboarding screens so users can choose their language before creating, importing or restoring a wallet. Until now the language could only be changed in **Settings → General**, which is reachable only after a wallet exists — so wallet creation, seed backup and restore were English-only at first launch.

## What
- A language dropdown in the **top-right** of every onboarding screen (intro, create wallet, generate/verify seed, password, restore, node setup, account label, unlock, migrate), mirroring the existing network selector in the top-left.
- Reuses the existing Settings language combobox, extracted into a shared `LanguageComboBox` control (now used by both Settings → General and the start screens).
- Language changes ride the existing `WalletSettings::setLocaleByLanguageName` → `localeChanged` → `Translator::retranslate()` pipeline, so the whole flow retranslates live and the choice persists into Settings and across restarts.
- No new translatable strings — native language names come from `QLocale::nativeLanguageName()`.

## Implementation
- `StartViewModel` gains a `supportedLanguages` / `currentLanguage` / `currentLanguageIndex` trio mirroring its existing network-selector trio (so it works pre-wallet, where `SettingsViewModel` cannot be used).
- `LanguageComboBox` is placed in both onboarding base layouts (`StartLayout`, `WizzardPage`); the version label is re-anchored beneath it.

## Also fixed (found while testing the selector in other languages)
- **Qt 6 deprecation:** the `LanguageComboBox` signal handler now declares a formal `language` parameter instead of relying on injected signal parameters.
- **German migration message** word order — the version was appended after the verb (`…migriert <version>`); reworded so it reads `…migriert auf v<version>`.
- **`OpenWalletPage`** was missing the `firstButton*` properties the migration flow assigns, which logged *"Cannot assign to non-existent property"* and left the migration **Back** button non-functional.

## Notes
- Built and tested on macOS (Qt 6.8.3, Apple clang 21). The clang-21 build fixes required on recent toolchains come via #1251 and are intentionally not included here.
