### PR TITLE
Fix QtObject imports for Qt6 QML controls

### DIFF
--- a/ui/view/addresses.qml
+++ b/ui/view/addresses.qml
@@ -172,7 +172,7 @@ ColumnLayout {
             
                 anchors.fill: parent
                 frameVisible: false
-                selectionMode: SelectionMode.noSelection
+                selectionMode: 0
                 backgroundVisible: false
                 model: viewModel.contacts
                 sortIndicatorVisible: true

--- a/ui/view/applications/PublishersList.qml
+++ b/ui/view/applications/PublishersList.qml
@@ -39,7 +39,7 @@ ColumnLayout {
         Layout.fillWidth:  true
         Layout.topMargin:  20
 
-        selectionMode:        SelectionMode.noSelection
+        selectionMode:        0
         sortIndicatorVisible: true
         sortIndicatorColumn:  0
         sortIndicatorOrder:   Qt.DescendingOrder

--- a/ui/view/assets_swap.qml
+++ b/ui/view/assets_swap.qml
@@ -155,7 +155,7 @@ ColumnLayout {
 
         property var          selectedAssets: []
 
-        selectionMode: SelectionMode.noSelection
+        selectionMode: 0
         sortIndicatorVisible: true
         sortIndicatorColumn: 4
         sortIndicatorOrder: Qt.DescendingOrder

--- a/ui/view/atomic_swap.qml
+++ b/ui/view/atomic_swap.qml
@@ -508,7 +508,7 @@ Please try again later or create an offer yourself."
                 property int columnWidth: (width - swapCoinsColumn.width) / 6
 
                 frameVisible: false
-                selectionMode: SelectionMode.noSelection
+                selectionMode: 0
                 backgroundVisible: false
                 sortIndicatorVisible: true
                 sortIndicatorColumn: 1
@@ -825,7 +825,7 @@ Please try again later or create an offer yourself."
                 property int columnWidth: (width - txSwapCoinsColumn.width - txSwapActionColumn.width) / 6
 
                 frameVisible: false
-                selectionMode: SelectionMode.noSelection
+                selectionMode: 0
                 backgroundVisible: false
                 sortIndicatorVisible: true
                 sortIndicatorColumn: 1

--- a/ui/view/controls/AddressTable.qml
+++ b/ui/view/controls/AddressTable.qml
@@ -16,7 +16,7 @@ CustomTableView {
     property var showQRDialog
     anchors.fill: parent
     frameVisible: false
-    selectionMode: SelectionMode.noSelection
+    selectionMode: 0
     backgroundVisible: false
     sortIndicatorVisible: true
     sortIndicatorColumn: 0

--- a/ui/view/controls/MaxPrivacyCoinsDialog.qml
+++ b/ui/view/controls/MaxPrivacyCoinsDialog.qml
@@ -76,7 +76,7 @@ CustomDialog {
             Layout.fillWidth:    true
             Layout.fillHeight:   true
             frameVisible:        false
-            selectionMode:       SelectionMode.noSelection
+            selectionMode:       0
             backgroundVisible:   false
             headerColor:         Style.background_main_top
             mainBackgroundRect:  dialog.background

--- a/ui/view/controls/SelectionMode.qml
+++ b/ui/view/controls/SelectionMode.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import QtQuick
+import QtQml
 
 QtObject {
     readonly property int noSelection: 0

--- a/ui/view/controls/SelectionMode.qml
+++ b/ui/view/controls/SelectionMode.qml
@@ -1,5 +1,3 @@
-pragma Singleton
-
 import QtQml
 
 QtObject {

--- a/ui/view/controls/TableViewColumn.qml
+++ b/ui/view/controls/TableViewColumn.qml
@@ -1,3 +1,4 @@
+import QtQml
 import QtQuick
 
 QtObject {

--- a/ui/view/controls/UtxoDialog.qml
+++ b/ui/view/controls/UtxoDialog.qml
@@ -43,7 +43,7 @@ CustomDialog {
             Layout.fillHeight: true
             Layout.bottomMargin: 9
             visible: tableView.model.count > 0
-            selectionMode: SelectionMode.noSelection
+            selectionMode: 0
             backgroundVisible: false
             headerColor: Qt.rgba(Style.active.r, Style.active.g, Style.active.b, 0.1)
             mainBackgroundRect: dialog.background

--- a/ui/view/controls/qmldir
+++ b/ui/view/controls/qmldir
@@ -1,2 +1,1 @@
 singleton Style 1.0 Style.qml
-singleton SelectionMode 1.0 SelectionMode.qml

--- a/ui/view/start_wizzard/SelectWalletDBPage.qml
+++ b/ui/view/start_wizzard/SelectWalletDBPage.qml
@@ -46,7 +46,7 @@ WizzardPage {
         Layout.minimumWidth: minWidth
         Layout.maximumWidth: minWidth
         frameVisible: false
-        selectionMode: SelectionMode.singleSelection
+        selectionMode: 1
         backgroundVisible: false
         model: viewModel.walletDBpaths
 

--- a/ui/view/wallet/TxTable.qml
+++ b/ui/view/wallet/TxTable.qml
@@ -401,7 +401,7 @@ Control {
             property real resizableWidth: transactionsTable.width - 140
             property real columnResizeRatio: resizableWidth / (610 - (sourceVisible || actionVisible ? 0 : 140))
 
-            selectionMode: SelectionMode.noSelection
+            selectionMode: 0
             sortIndicatorVisible: true
             sortIndicatorColumn: 5
             sortIndicatorOrder: Qt.DescendingOrder


### PR DESCRIPTION
Closing this PR because the QML changes did not resolve the underlying issue.

The official release now works after following these steps:

1. Reinstall the previous working Qt5-based Beam Wallet version.

2. Uninstall that version normally.

3. Install the new Qt6-based Beam Wallet release.

It appears my initial Qt6 installation was installed over the older version and

some legacy Qt5 deployment files may have remained. A normal uninstall/reinstall of only the new version did not fix it, but reinstalling and uninstalling the old version first did.

This is a workaround rather than a confirmed root-cause fix.