### PR TITLE
#1133: Show specific DApp install error messages

### DIFF
--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -3553,12 +3553,6 @@ Uninstall failed. Please try again later.</source>
         <translation>Віншуем!
 DApp &apos;%1&apos; паспяхова ўсталяваны.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>На жаль, усталяванне не атрымалася.
-Калі ласка, праверце файл і паўтарыце спробу.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3942,6 +3936,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Не ўдалося адкрыць файл DApp. Магчыма, ён пашкоджаны.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Не ўдалося прачытаць маніфест DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Гэтая DApp не падтрымліваецца вашай версіяй кашалька.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Няправільны файл DApp: маніфест адсутнічае або няпоўны.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Гэтая DApp ужо ўсталявана.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Не ўдалося падрыхтаваць папку ўсталявання.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Не ўдалося распакаваць файлы DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -3553,12 +3553,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3942,6 +3936,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Soubor DApp se nepodařilo otevřít. Může být poškozený.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Manifest DApp se nepodařilo přečíst.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Tato DApp není podporována vaší verzí peněženky.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Neplatný soubor DApp: manifest chybí nebo je neúplný.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Tato DApp je již nainstalována.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Nepodařilo se připravit instalační složku.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Soubory DApp se nepodařilo rozbalit.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -3538,12 +3538,6 @@ Deinstallation fehlgeschlagen. Bitte versuchen Sie es später erneut.</translati
         <translation>Herzlichen Glückwunsch!
 &apos;%1&apos; DApp ist erfolgreich installiert.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Die Installation ist fehlgeschlagen.
-Bitte überprüfen Sie die Datei und versuchen Sie es erneut.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Mein DApp Store</translation>
@@ -3927,6 +3921,34 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Die DApp-Datei konnte nicht geöffnet werden. Sie ist möglicherweise beschädigt.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Das DApp-Manifest konnte nicht gelesen werden.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Diese DApp wird von Ihrer Wallet-Version nicht unterstützt.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Ungültige DApp-Datei: Das Manifest fehlt oder ist unvollständig.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Diese DApp ist bereits installiert.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Der Installationsordner konnte nicht vorbereitet werden.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Die DApp-Dateien konnten nicht entpackt werden.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -3570,12 +3570,6 @@ Uninstall failed. Please try again later.</translation>
         <translation>Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3931,6 +3925,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="general-copy-SBBS-and-close">
         <source>copy SBBS address and close</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Couldn&apos;t open the DApp file. It may be corrupted.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Couldn&apos;t read the DApp manifest.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>This DApp is not supported by your wallet version.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Invalid DApp file: the manifest is missing or incomplete.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>This DApp is already installed.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Couldn&apos;t prepare the installation folder.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Couldn&apos;t extract the DApp files.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -3542,12 +3542,6 @@ La desinstalación falló. Inténtelo de nuevo más tarde.</translation>
         <translation>¡Felicitaciones!
 &apos;%1&apos; DApp instalado correctamente.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Lo sentimos, la instalación falló.
-Por favor, comprueba el archivo e inténtelo de nuevo.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Tienda Dapp</translation>
@@ -3931,6 +3925,34 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>No se pudo abrir el archivo de la DApp. Puede estar dañado.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>No se pudo leer el manifiesto de la DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Esta DApp no es compatible con tu versión de la cartera.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Archivo de DApp no válido: falta el manifiesto o está incompleto.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Esta DApp ya está instalada.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>No se pudo preparar la carpeta de instalación.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>No se pudieron extraer los archivos de la DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -3544,12 +3544,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3933,6 +3927,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>DApp-tiedostoa ei voitu avata. Se voi olla vioittunut.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>DApp-manifestia ei voitu lukea.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Lompakkoversiosi ei tue tätä DAppia.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Virheellinen DApp-tiedosto: manifesti puuttuu tai on puutteellinen.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Tämä DApp on jo asennettu.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Asennuskansiota ei voitu valmistella.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>DApp-tiedostoja ei voitu purkaa.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -3540,12 +3540,6 @@ La désinstallation a échoué. Veuillez réessayer plus tard.</translation>
         <translation>Félicitations !
 La DApp &apos;%1&apos; est installée avec succès.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Désolé, l&apos;installation a échoué.
-Veuillez vérifier le fichier et réessayer.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>DApp Store</translation>
@@ -3929,6 +3923,34 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Impossible d'ouvrir le fichier DApp. Il est peut-être corrompu.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Impossible de lire le manifeste de la DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Cette DApp n'est pas prise en charge par votre version du portefeuille.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Fichier DApp invalide : le manifeste est manquant ou incomplet.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Cette DApp est déjà installée.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Impossible de préparer le dossier d'installation.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Impossible d'extraire les fichiers de la DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -3535,12 +3535,6 @@ Pencopotan pemasangan gagal. Silakan coba lagi nanti.</translation>
         <translation>Selamat!
 &apos;%1&apos; DApp berhasil diinstal.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Maaf, penginstalan gagal.
-Silakan periksa file dan coba lagi.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3923,6 +3917,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Tidak dapat membuka berkas DApp. Berkas mungkin rusak.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Tidak dapat membaca manifest DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>DApp ini tidak didukung oleh versi dompet Anda.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Berkas DApp tidak valid: manifest hilang atau tidak lengkap.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>DApp ini sudah terpasang.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Tidak dapat menyiapkan folder pemasangan.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Tidak dapat mengekstrak berkas DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -3542,12 +3542,6 @@ Disinstallazione fallita. Per favore riprova più tardi.</translation>
         <translation>Congratulazioni!
 &apos;%1&apos; DApp è stato installato correttamente.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Siamo spiacenti, l&apos;installazione è fallita.
-Controllare il file e riprovare.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3931,6 +3925,34 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Impossibile aprire il file della DApp. Potrebbe essere danneggiato.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Impossibile leggere il manifesto della DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Questa DApp non è supportata dalla tua versione del wallet.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>File DApp non valido: il manifesto è mancante o incompleto.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Questa DApp è già installata.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Impossibile preparare la cartella di installazione.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Impossibile estrarre i file della DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -3511,12 +3511,6 @@ Uninstall failed. Please try again later.</source>
         <translation>おめでとうございます！
 %1 DAppのインストールに成功しました。</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>インストールに失敗しました。
-ファイルを確認してもう一度お試しください。</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>DAPP Store</translation>
@@ -3900,6 +3894,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>DAppファイルを開けませんでした。破損している可能性があります。</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>DAppのマニフェストを読み取れませんでした。</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>このDAppはお使いのウォレットのバージョンではサポートされていません。</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>無効なDAppファイル：マニフェストが見つからないか、不完全です。</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>このDAppはすでにインストールされています。</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>インストールフォルダーを準備できませんでした。</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>DAppファイルを展開できませんでした。</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -3534,12 +3534,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3923,6 +3917,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>DApp 파일을 열 수 없습니다. 파일이 손상되었을 수 있습니다.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>DApp 매니페스트를 읽을 수 없습니다.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>이 DApp은 현재 지갑 버전에서 지원되지 않습니다.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>잘못된 DApp 파일: 매니페스트가 없거나 불완전합니다.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>이 DApp은 이미 설치되어 있습니다.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>설치 폴더를 준비할 수 없습니다.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>DApp 파일의 압축을 풀 수 없습니다.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -3539,12 +3539,6 @@ Verwijderen mislukt. Probeer het later opnieuw.</translation>
         <translation>Gefeliciteerd!
 &apos;%1&apos; DApp is succesvol geïnstalleerd.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Sorry, de installatie is mislukt.
-Controleer het bestand en probeer het opnieuw.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3928,6 +3922,34 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Kan het DApp-bestand niet openen. Het is mogelijk beschadigd.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Kan het DApp-manifest niet lezen.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Deze DApp wordt niet ondersteund door jouw versie van de wallet.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Ongeldig DApp-bestand: het manifest ontbreekt of is onvolledig.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Deze DApp is al geïnstalleerd.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Kan de installatiemap niet voorbereiden.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Kan de DApp-bestanden niet uitpakken.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -3541,12 +3541,6 @@ Falha na desinstalação. Por favor, tente novamente mais tarde.</translation>
         <translation>Parabéns!
 &apos;%1&apos; DApp instalado com sucesso.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>Desculpe, a instalação falhou.
-Por favor, verifique o arquivo e tente novamente.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>DApp Store</translation>
@@ -3930,6 +3924,34 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Não foi possível abrir o arquivo da DApp. Ele pode estar corrompido.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Não foi possível ler o manifesto da DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Esta DApp não é compatível com a sua versão da carteira.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Arquivo de DApp inválido: o manifesto está ausente ou incompleto.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Esta DApp já está instalada.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Não foi possível preparar a pasta de instalação.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Não foi possível extrair os arquivos da DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -3555,12 +3555,6 @@ Uninstall failed. Please try again later.</source>
         <translation>Поздравляем!
 DApp &apos;%1&apos; успешно установлен.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>К сожалению, установка не удалась.
-Пожалуйста, проверьте файл и повторите попытку.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3944,6 +3938,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Не удалось открыть файл DApp. Возможно, он повреждён.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Не удалось прочитать манифест DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Эта DApp не поддерживается вашей версией кошелька.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Недопустимый файл DApp: манифест отсутствует или неполный.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Эта DApp уже установлена.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Не удалось подготовить папку установки.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Не удалось распаковать файлы DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -3558,12 +3558,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3955,6 +3949,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Nije moguće otvoriti DApp datoteku. Možda je oštećena.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Nije moguće pročitati DApp manifest.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Ovu DApp ne podržava vaša verzija novčanika.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Nevažeća DApp datoteka: manifest nedostaje ili je nepotpun.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Ova DApp je već instalirana.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Nije moguće pripremiti instalacioni folder.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Nije moguće raspakovati DApp datoteke.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -3540,12 +3540,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3929,6 +3923,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Det gick inte att öppna DApp-filen. Den kan vara skadad.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Det gick inte att läsa DApp-manifestet.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Den här DAppen stöds inte av din version av plånboken.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Ogiltig DApp-fil: manifestet saknas eller är ofullständigt.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Den här DAppen är redan installerad.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Det gick inte att förbereda installationsmappen.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Det gick inte att extrahera DApp-filerna.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -3534,12 +3534,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3923,6 +3917,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>ไม่สามารถเปิดไฟล์ DApp ได้ ไฟล์อาจเสียหาย</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>ไม่สามารถอ่านไฟล์ manifest ของ DApp ได้</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>DApp นี้ไม่รองรับกับเวอร์ชันกระเป๋าเงินของคุณ</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>ไฟล์ DApp ไม่ถูกต้อง: ไม่มีไฟล์ manifest หรือไม่สมบูรณ์</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>DApp นี้ติดตั้งไว้แล้ว</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>ไม่สามารถเตรียมโฟลเดอร์การติดตั้งได้</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>ไม่สามารถแตกไฟล์ DApp ได้</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -3534,12 +3534,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3923,6 +3917,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>DApp dosyası açılamadı. Bozulmuş olabilir.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>DApp bildirimi (manifest) okunamadı.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Bu DApp, cüzdan sürümünüz tarafından desteklenmiyor.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Geçersiz DApp dosyası: manifest eksik veya tamamlanmamış.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Bu DApp zaten yüklü.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Kurulum klasörü hazırlanamadı.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>DApp dosyaları çıkarılamadı.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -3550,12 +3550,6 @@ Uninstall failed. Please try again later.</source>
         <translation>Щиро вітаю!
 &apos;%1&apos; DApp успішно встановлено.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>На жаль, не вдалося встановити.
-Перевірте файл і повторіть спробу.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>Dapp Store</translation>
@@ -3939,6 +3933,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Не вдалося відкрити файл DApp. Можливо, він пошкоджений.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Не вдалося прочитати маніфест DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>Ця DApp не підтримується вашою версією гаманця.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Недійсний файл DApp: маніфест відсутній або неповний.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>Ця DApp вже встановлена.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Не вдалося підготувати папку встановлення.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Не вдалося розпакувати файли DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -3539,12 +3539,6 @@ Uninstall failed. Please try again later.</translation>
         <translation type="unfinished">Congratulations!
 &apos;%1&apos; DApp is successfully installed.</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation type="unfinished">Sorry, the installation failed.
-Please, check the file and try again.</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation type="unfinished">Dapp Store</translation>
@@ -3936,6 +3930,34 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>Không thể mở tệp DApp. Tệp có thể đã bị hỏng.</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>Không thể đọc manifest của DApp.</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>DApp này không được hỗ trợ bởi phiên bản ví của bạn.</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>Tệp DApp không hợp lệ: thiếu manifest hoặc manifest không đầy đủ.</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>DApp này đã được cài đặt.</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>Không thể chuẩn bị thư mục cài đặt.</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>Không thể giải nén các tệp DApp.</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -3550,12 +3550,6 @@ Uninstall failed. Please try again later.</source>
         <translation>恭喜！
 &apos;%1&apos;DApp已成功安装</translation>
     </message>
-    <message id="app-install-fail">
-        <source>Sorry, the installation failed.
-Please, check the file and try again.</source>
-        <translation>对不起，安装失败，
-请检查文件并再试一次。</translation>
-    </message>
     <message id="dapp-store-dialog-title">
         <source>Dapp Store</source>
         <translation>DApp商店</translation>
@@ -3939,6 +3933,34 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="settings-remove-wallet-password-button">
         <source>remove</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="dapp-install-err-cant-open">
+        <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
+        <translation>无法打开 DApp 文件，该文件可能已损坏。</translation>
+    </message>
+    <message id="dapp-install-err-cant-read-manifest">
+        <source>Couldn&apos;t read the DApp manifest.</source>
+        <translation>无法读取 DApp 清单文件。</translation>
+    </message>
+    <message id="dapp-install-err-unsupported">
+        <source>This DApp is not supported by your wallet version.</source>
+        <translation>您的钱包版本不支持此 DApp。</translation>
+    </message>
+    <message id="dapp-install-err-invalid">
+        <source>Invalid DApp file: the manifest is missing or incomplete.</source>
+        <translation>无效的 DApp 文件：清单缺失或不完整。</translation>
+    </message>
+    <message id="dapp-install-err-already-installed">
+        <source>This DApp is already installed.</source>
+        <translation>此 DApp 已安装。</translation>
+    </message>
+    <message id="dapp-install-err-folder">
+        <source>Couldn&apos;t prepare the installation folder.</source>
+        <translation>无法准备安装文件夹。</translation>
+    </message>
+    <message id="dapp-install-err-extract">
+        <source>Couldn&apos;t extract the DApp files.</source>
+        <translation>无法解压 DApp 文件。</translation>
     </message>
 </context>
 </TS>

--- a/ui/view/applications/AppView.qml
+++ b/ui/view/applications/AppView.qml
@@ -107,9 +107,8 @@ ColumnLayout {
             dappStoreOk.open()
         }
 
-        onAppInstallFail: function (appName) {
-            //% "Sorry, the installation failed.\nPlease, check the file and try again."
-            dappStoreFail.text = qsTrId("app-install-fail")
+        onAppInstallFail: function (errorCode, appName) {
+            dappStoreFail.text = DAppInstallErrors.text(errorCode)
             dappStoreFail.open()
         }
 

--- a/ui/view/applications/applications.qml
+++ b/ui/view/applications/applications.qml
@@ -85,12 +85,13 @@ ColumnLayout {
             if (!fname) return
         }
 
-        var appName = viewModel.installFromFile(fname)
-        if (appName.length) {
+        var res = viewModel.installFromFile(fname)
+        if (res.errorCode === ApplicationsViewModel.Ok) {
             dndDialog.isOk = true;
-            dndDialog.appName = appName;
+            dndDialog.appName = res.appName;
         } else {
             dndDialog.isFail = true;
+            dndDialog.errorText = DAppInstallErrors.text(res.errorCode);
         }
     }
 
@@ -132,9 +133,8 @@ ColumnLayout {
             dappStoreOk.open()
         }
 
-        onAppInstallFail: function (appName) {
-            //% "Sorry, the installation failed.\nPlease, check the file and try again."
-            dappStoreFail.text = qsTrId("app-install-fail")
+        onAppInstallFail: function (errorCode, appName) {
+            dappStoreFail.text = DAppInstallErrors.text(errorCode)
             dappStoreFail.open()
         }
 

--- a/ui/view/controls/DAppInstallErrors.qml
+++ b/ui/view/controls/DAppInstallErrors.qml
@@ -1,0 +1,38 @@
+pragma Singleton
+
+import QtQuick
+import Beam.Wallet 1.0
+
+// Maps AppsViewModel::DAppInstallError codes to translatable, user-facing text.
+// Shared by the manual install dialog (DnDdappInstallDialog) and the DApp store
+// install popup so both paths show the same specific reasons.
+QtObject {
+    function text(errorCode) {
+        switch (errorCode) {
+        case ApplicationsViewModel.CantOpenFile:
+            //% "Couldn't open the DApp file. It may be corrupted."
+            return qsTrId("dapp-install-err-cant-open")
+        case ApplicationsViewModel.CantReadManifest:
+            //% "Couldn't read the DApp manifest."
+            return qsTrId("dapp-install-err-cant-read-manifest")
+        case ApplicationsViewModel.Unsupported:
+            //% "This DApp is not supported by your wallet version."
+            return qsTrId("dapp-install-err-unsupported")
+        case ApplicationsViewModel.InvalidFile:
+            //% "Invalid DApp file: the manifest is missing or incomplete."
+            return qsTrId("dapp-install-err-invalid")
+        case ApplicationsViewModel.AlreadyInstalled:
+            //% "This DApp is already installed."
+            return qsTrId("dapp-install-err-already-installed")
+        case ApplicationsViewModel.FolderPrepFailed:
+            //% "Couldn't prepare the installation folder."
+            return qsTrId("dapp-install-err-folder")
+        case ApplicationsViewModel.ExtractFailed:
+            //% "Couldn't extract the DApp files."
+            return qsTrId("dapp-install-err-extract")
+        default:
+            //% "The DApp installation error."
+            return qsTrId("dnd-install-fail")
+        }
+    }
+}

--- a/ui/view/controls/DAppInstallErrors.qml
+++ b/ui/view/controls/DAppInstallErrors.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import QtQuick
+import QtQml
 import Beam.Wallet 1.0
 
 // Maps AppsViewModel::DAppInstallError codes to translatable, user-facing text.

--- a/ui/view/controls/DnDdappInstallDialog.qml
+++ b/ui/view/controls/DnDdappInstallDialog.qml
@@ -13,11 +13,13 @@ CustomDialog {
     property bool isOk: false
     property bool isFail: false
     property string appName: ""
+    property string errorText: ""
 
     onOpened: {
         control.isOk = false;
         control.isFail = false;
         control.appName = "";
+        control.errorText = "";
     }
 
     modal: true
@@ -131,8 +133,11 @@ CustomDialog {
                 }
                 color: Style.validator_error
                 //% "The DApp installation error."
-                text: qsTrId("dnd-install-fail")
+                text: control.errorText.length ? control.errorText : qsTrId("dnd-install-fail")
                 visible: control.isFail
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                Layout.fillWidth: true
             }
 
             SvgImage {

--- a/ui/view/controls/qmldir
+++ b/ui/view/controls/qmldir
@@ -1,2 +1,3 @@
 singleton Style 1.0 Style.qml
 singleton SelectionMode 1.0 SelectionMode.qml
+singleton DAppInstallErrors 1.0 DAppInstallErrors.qml

--- a/ui/view/qml.qrc
+++ b/ui/view/qml.qrc
@@ -33,6 +33,7 @@
         <file>controls/CustomScrollBar.qml</file>
         <file>controls/TableViewColumn.qml</file>
         <file>controls/SelectionMode.qml</file>
+        <file>controls/DAppInstallErrors.qml</file>
         <file>controls/FeeSlider.qml</file>
         <file>controls/SFFontLoader.qml</file>
         <file>controls/SFTextArea.qml</file>

--- a/ui/viewmodel/applications/apps_view.cpp
+++ b/ui/viewmodel/applications/apps_view.cpp
@@ -26,9 +26,21 @@
 #include "viewmodel/qml_globals.h"
 #include "wallet/api/i_wallet_api.h"
 #include "wallet/client/apps_api/apps_utils.h"
+#include <stdexcept>
 
 namespace
 {
+    using DAppInstallError = beamui::applications::AppsViewModel::DAppInstallError;
+
+    // Carries the specific reason of a DApp installation failure so it can be
+    // surfaced in the UI instead of being flattened into a generic message.
+    struct DAppInstallException : std::runtime_error
+    {
+        DAppInstallError code;
+        DAppInstallException(DAppInstallError c, const char* what)
+            : std::runtime_error(what), code(c) {}
+    };
+
     const uint8_t kCountApiVersionParts = 2;
     const uint8_t kCountDAppVersionParts = 4;
     const QString kBeamPublisherName = "Beam Development Limited";
@@ -1594,17 +1606,18 @@ namespace beamui::applications
         const auto defaultPath = app[DApp::kDefaultDappPath].toString();
         if (!defaultPath.isEmpty())
         {
-            const auto appName = installFromFileImpl(defaultPath,
+            const auto result = installFromFileImpl(defaultPath,
                 [](const QString&) { return false; },
                 [this]() { loadApps(); });
 
-            if (!appName.isEmpty())
+            const auto errorCode = result["errorCode"].toInt();
+            if (errorCode == static_cast<int>(DAppInstallError::Ok))
             {
-                emit appInstallOK(appName);
+                emit appInstallOK(result["appName"].toString());
             }
             else
             {
-                emit appInstallFail(app[DApp::kName].toString());
+                emit appInstallFail(errorCode, app[DApp::kName].toString());
             }
             return;
         }
@@ -1643,10 +1656,15 @@ namespace beamui::applications
                         emit appInstallOK(appName);
                         loadApps();
                     }
+                    catch (const DAppInstallException& err)
+                    {
+                        BEAM_LOG_ERROR() << "Failed to install DApp: " << err.what();
+                        emit appInstallFail(static_cast<int>(err.code), appName);
+                    }
                     catch (std::runtime_error& err)
                     {
                         BEAM_LOG_ERROR() << "Failed to install DApp: " << err.what();
-                        emit appInstallFail(appName);
+                        emit appInstallFail(static_cast<int>(DAppInstallError::Unknown), appName);
                     }
                 },
                 [this, guard, appName, guid](std::string&& err)
@@ -1662,7 +1680,7 @@ namespace beamui::applications
             assert(false);
             BEAM_LOG_ERROR() << "Failed to get properties for " << guid.toStdString() << ", " << err.what();
 
-            emit appInstallFail("");
+            emit appInstallFail(static_cast<int>(DAppInstallError::Unknown), "");
             return;
         }
 #endif // BEAM_IPFS_SUPPORT
@@ -1677,37 +1695,49 @@ namespace beamui::applications
         {
             if (!QDir(appFolder).removeRecursively())
             {
-                throw std::runtime_error("Failed to prepare folder");
+                throw DAppInstallException(DAppInstallError::FolderPrepFailed, "Failed to prepare folder");
             }
         }
 
         QDir(appsPath).mkdir(guid);
         if (JlCompress::extractDir(ioDevice, appFolder).isEmpty())
         {
-            throw std::runtime_error("DApp Installation failed");
+            throw DAppInstallException(DAppInstallError::ExtractFailed, "DApp Installation failed");
         }
     }
 
-    QString AppsViewModel::installFromFile(const QString& rawFname)
+    namespace
     {
-        return installFromFileImpl(rawFname, 
+        // Builds the QVariantMap returned by installFromFile* : { appName, errorCode }.
+        QVariantMap makeInstallResult(const QString& appName, DAppInstallError code)
+        {
+            QVariantMap result;
+            result["appName"] = appName;
+            result["errorCode"] = static_cast<int>(code);
+            return result;
+        }
+    }
+
+    QVariantMap AppsViewModel::installFromFile(const QString& rawFname)
+    {
+        return installFromFileImpl(rawFname,
             [this](const QString& guid)
             {
                 const auto app = getAppByGUID(guid);
                 return !app.isEmpty();
             },
-            [this]() 
+            [this]()
             {
                 loadApps();
             });
     }
 
-    QString AppsViewModel::installFromFile2(const QString& rawFname)
+    QVariantMap AppsViewModel::installFromFile2(const QString& rawFname)
     {
         return installFromFileImpl(rawFname, [](const QString&) {return false; }, []() {});
     }
 
-    QString AppsViewModel::installFromFileImpl(const QString& rawFname, std::function<bool(const QString&)> appExists, std::function<void()> afterInstallAction)
+    QVariantMap AppsViewModel::installFromFileImpl(const QString& rawFname, std::function<bool(const QString&)> appExists, std::function<void()> afterInstallAction)
     {
         try
         {
@@ -1718,7 +1748,7 @@ namespace beamui::applications
             QuaZip zip(fname);
             if (!zip.open(QuaZip::Mode::mdUnzip))
             {
-                throw std::runtime_error("Failed to open the DApp file");
+                throw DAppInstallException(DAppInstallError::CantOpenFile, "Failed to open the DApp file");
             }
 
             QString guid, appName;
@@ -1730,7 +1760,7 @@ namespace beamui::applications
                     QuaZipFile mfile(zip.getZipName(), zipFname);
                     if (!mfile.open(QIODevice::ReadOnly))
                     {
-                        throw std::runtime_error("Failed to read the DApp file");
+                        throw DAppInstallException(DAppInstallError::CantReadManifest, "Failed to read the DApp file");
                     }
 
                     QTextStream in(&mfile);
@@ -1740,19 +1770,19 @@ namespace beamui::applications
 
                     if (!isAppSupported(app))
                     {
-                        throw std::runtime_error("DApp is unsupported.");
+                        throw DAppInstallException(DAppInstallError::Unsupported, "DApp is unsupported.");
                     }
                 }
             }
 
             if (guid.isEmpty())
             {
-                throw std::runtime_error("Invalid DApp file");
+                throw DAppInstallException(DAppInstallError::InvalidFile, "Invalid DApp file");
             }
 
             if (appExists && appExists(guid))
             {
-                throw std::runtime_error("DApp with same guid already installed!");
+                throw DAppInstallException(DAppInstallError::AlreadyInstalled, "DApp with same guid already installed!");
             }
 
             const auto appsPath = AppSettings().getLocalAppsPath();
@@ -1762,7 +1792,7 @@ namespace beamui::applications
             {
                 if (!QDir(appFolder).removeRecursively())
                 {
-                    throw std::runtime_error("Failed to prepare folder");
+                    throw DAppInstallException(DAppInstallError::FolderPrepFailed, "Failed to prepare folder");
                 }
             }
 
@@ -1770,7 +1800,7 @@ namespace beamui::applications
             if (JlCompress::extractDir(fname, appFolder).isEmpty())
             {
                 //cleanupFolder(appFolder)
-                throw std::runtime_error("DApp Installation failed");
+                throw DAppInstallException(DAppInstallError::ExtractFailed, "DApp Installation failed");
             }
 
             // refresh
@@ -1779,12 +1809,17 @@ namespace beamui::applications
                 afterInstallAction();
             }
 
-            return appName;
+            return makeInstallResult(appName, DAppInstallError::Ok);
+        }
+        catch (const DAppInstallException& err)
+        {
+            BEAM_LOG_ERROR() << "Failed to install DApp: " << err.what();
+            return makeInstallResult("", err.code);
         }
         catch (std::exception& err)
         {
             BEAM_LOG_ERROR() << "Failed to install DApp: " << err.what();
-            return "";
+            return makeInstallResult("", DAppInstallError::Unknown);
         }
     }
 
@@ -2123,7 +2158,7 @@ namespace beamui::applications
                                 throw std::runtime_error("Failed to restore folder");
                             }
 
-                            throw std::runtime_error("DApp Installation failed");
+                            throw DAppInstallException(DAppInstallError::ExtractFailed, "DApp Installation failed");
                         }
 
                         if (!QDir(appsDir.filePath(backupName)).removeRecursively())
@@ -2237,7 +2272,7 @@ namespace beamui::applications
         QuaZip zip(ioDevice);
         if (!zip.open(QuaZip::Mode::mdUnzip))
         {
-            throw std::runtime_error("Failed to open the DApp archive");
+            throw DAppInstallException(DAppInstallError::CantOpenFile, "Failed to open the DApp archive");
         }
 
         bool isFound = false;
@@ -2249,18 +2284,18 @@ namespace beamui::applications
                 QuaZipFile mfile(&zip);
                 if (!mfile.open(QIODevice::ReadOnly))
                 {
-                    throw std::runtime_error("Failed to read the DApp archive");
+                    throw DAppInstallException(DAppInstallError::CantReadManifest, "Failed to read the DApp archive");
                 }
 
                 QTextStream in(&mfile);
                 const auto app = parseAppManifest(in, "");
                 if (expectedGuid != app[DApp::kGuid].value<QString>())
                 {
-                    throw std::runtime_error("Wrong guid");
+                    throw DAppInstallException(DAppInstallError::InvalidFile, "Wrong guid");
                 }
                 if (expectedAppName != app[DApp::kName].value<QString>())
                 {
-                    throw std::runtime_error("Wrong name of app");
+                    throw DAppInstallException(DAppInstallError::InvalidFile, "Wrong name of app");
                 }
                 isFound = true;
             }
@@ -2268,7 +2303,7 @@ namespace beamui::applications
 
         if (!isFound)
         {
-            throw std::runtime_error("Maybe dapp file is broken");
+            throw DAppInstallException(DAppInstallError::InvalidFile, "Maybe dapp file is broken");
         }
     }
 }

--- a/ui/viewmodel/applications/apps_view.h
+++ b/ui/viewmodel/applications/apps_view.h
@@ -129,6 +129,20 @@ namespace beamui::applications
             Governance
         };
 
+        enum class DAppInstallError
+        {
+            Ok = 0,
+            CantOpenFile,       // zip won't open
+            CantReadManifest,   // manifest unreadable
+            Unsupported,        // isAppSupported == false
+            InvalidFile,        // no guid / missing manifest
+            AlreadyInstalled,   // same guid already installed
+            FolderPrepFailed,   // couldn't prepare target folder
+            ExtractFailed,      // extraction failed
+            Unknown             // any other failure
+        };
+        Q_ENUM(DAppInstallError)
+
         AppsViewModel();
         ~AppsViewModel() override;
 
@@ -157,8 +171,8 @@ namespace beamui::applications
         Q_INVOKABLE void removeDApp(const QString& guid);
         Q_INVOKABLE bool checkDAppNewVersion(const QVariantMap& currentDApp, const QVariantMap& newDApp);
         Q_INVOKABLE void installApp(const QString& guid);
-        Q_INVOKABLE [[nodiscard]] QString installFromFile(const QString& fname);
-        static QString installFromFile2(const QString& fname);
+        Q_INVOKABLE [[nodiscard]] QVariantMap installFromFile(const QString& fname);
+        static QVariantMap installFromFile2(const QString& fname);
         Q_INVOKABLE void updateDApp(const QString& guid);
         Q_INVOKABLE void launchAppServer();
         Q_INVOKABLE [[nodiscard]] bool uninstallLocalApp(const QString& appid);
@@ -190,7 +204,7 @@ namespace beamui::applications
         void publisherCreateFail();
         void publisherEditFail();
         void appInstallOK(const QString& appName);
-        void appInstallFail(const QString& appName);
+        void appInstallFail(int errorCode, const QString& appName);
         void appInstallTimeoutFail(const QString& appName);
         void appUpdateFail(const QString& appName);
         void appUpdateTimeoutFail(const QString& appName);
@@ -205,7 +219,7 @@ namespace beamui::applications
         [[nodiscard]] static QString expandLocalFile(const QString& folder, const std::string& url);
         QVariantMap parseAppManifest(QTextStream& io, const QString& appFolder, bool needExpandIcon = true);
         static QVariantMap parseAppManifestImpl(QTextStream& io, const QString& appFolder, const QString& serverAddr = {}, bool needExpandIcon = true);
-        static QString installFromFileImpl(const QString& fname, std::function<bool(const QString&)> appExists, std::function<void()> afterInstallAction);
+        static QVariantMap installFromFileImpl(const QString& fname, std::function<bool(const QString&)> appExists, std::function<void()> afterInstallAction);
         void loadApps();
         void loadLocalApps();
         void loadDevApps();


### PR DESCRIPTION
Closes #1133.

## Problem
Installing a DApp that failed showed a single generic message — *"The DApp installation error."* — with no hint of the cause. The backend already distinguished the failure reasons (already installed, invalid file, unsupported, can't open, extraction failed, and so on) but collapsed every case into the empty/generic result before it reached the UI, so users had to dig through the log file.

## Change
- Introduce a `DAppInstallError` `Q_ENUM` carried from the install logic to QML via a `DAppInstallException`, so classification happens once at the throw sites.
- Manual install returns `{appName, errorCode}`; the store/IPFS path's `appInstallFail` gains an `errorCode` argument.
- A shared `DAppInstallErrors` QML singleton maps each code to a translatable message, used by both the manual install dialog and the DApp store popup. The generic string remains as the fallback.
- Translations for the seven new messages added across all supported languages.

## Testing
Built and run locally (release). Verified the dialog shows the specific reason — e.g. reinstalling an installed DApp now reads "This DApp is already installed." instead of the generic error.