### PR TITLE
#1176: Show all on-chain assets in receive amount dropdown

### DIFF
--- a/ui/model/assets_manager.cpp
+++ b/ui/model/assets_manager.cpp
@@ -21,6 +21,7 @@
 namespace
 {
     constexpr uint8_t ACAlpha = 252;
+    constexpr int AssetsListChangedDebounceMs = 100;
 
     beam::Asset::ID GetBeamXID()
     {
@@ -43,7 +44,7 @@ AssetsManager::AssetsManager(WalletModel::Ptr wallet, ExchangeRatesManager::Ptr 
     , _rates(std::move(rates))
 {
     _assetsListChangedTimer.setSingleShot(true);
-    _assetsListChangedTimer.setInterval(100);
+    _assetsListChangedTimer.setInterval(AssetsListChangedDebounceMs);
     connect(&_assetsListChangedTimer, &QTimer::timeout, this, &AssetsManager::assetsListChanged);
 
     connect(_wallet, &WalletModel::assetInfoChanged, this, &AssetsManager::onAssetInfo);

--- a/ui/model/assets_manager.cpp
+++ b/ui/model/assets_manager.cpp
@@ -42,6 +42,10 @@ AssetsManager::AssetsManager(WalletModel::Ptr wallet, ExchangeRatesManager::Ptr 
     : _wallet(std::move(wallet))
     , _rates(std::move(rates))
 {
+    _assetsListChangedTimer.setSingleShot(true);
+    _assetsListChangedTimer.setInterval(100);
+    connect(&_assetsListChangedTimer, &QTimer::timeout, this, &AssetsManager::assetsListChanged);
+
     connect(_wallet, &WalletModel::assetInfoChanged, this, &AssetsManager::onAssetInfo);
     connect(_rates.get(),  &ExchangeRatesManager::rateUnitChanged,   this,  &AssetsManager::assetsListChanged);
     connect(_rates.get(),  &ExchangeRatesManager::activeRateChanged, this,  &AssetsManager::assetsListChanged);
@@ -81,6 +85,13 @@ void AssetsManager::collectAssetInfo(beam::Asset::ID assetId)
     }
 }
 
+void AssetsManager::scheduleAssetsListChanged()
+{
+    // Restart on each update so a burst of asset-info replies (e.g. when the
+    // full on-chain list is loaded) collapses into a single assetsListChanged.
+    _assetsListChangedTimer.start();
+}
+
 void AssetsManager::onAssetInfo(beam::Asset::ID id, const beam::wallet::WalletAsset& asset)
 {
     _requested.erase(id);
@@ -104,7 +115,7 @@ void AssetsManager::onAssetInfo(beam::Asset::ID id, const beam::wallet::WalletAs
         emit assetInfo(id);
     }
 
-    emit assetsListChanged();
+    scheduleAssetsListChanged();
 }
 
 AssetsManager::MetaPtr AssetsManager::getAsset(beam::Asset::ID id)
@@ -446,7 +457,7 @@ void AssetsManager::onAssetVerification(const std::vector<beam::wallet::Verifica
         m_vi[info.m_assetID] = info;
         emit assetInfo(info.m_assetID);
     }
-    emit assetsListChanged();
+    scheduleAssetsListChanged();
 }
 
 bool AssetsManager::isVerified(beam::Asset::ID assetId) const

--- a/ui/model/assets_manager.h
+++ b/ui/model/assets_manager.h
@@ -18,6 +18,7 @@
 #include <QMap>
 #include <QList>
 #include <QVariant>
+#include <QTimer>
 #include "wallet_model.h"
 #include "exchange_rates_manager.h"
 
@@ -69,6 +70,10 @@ private:
     // ASYNC
     void collectAssetInfo(beam::Asset::ID);
 
+    // Coalesce bursts of asset-info updates into a single assetsListChanged so
+    // consumers rebuild the (potentially large) list once, not once per asset.
+    void scheduleAssetsListChanged();
+
     typedef std::shared_ptr<beam::wallet::WalletAssetMeta> MetaPtr;
     typedef std::shared_ptr<beam::wallet::WalletAsset> AssetPtr;
     typedef std::pair<AssetPtr, MetaPtr> InfoPair;
@@ -83,6 +88,8 @@ private:
 
     std::map<int, QColor>  _colors;
     std::map<int, QString> _icons;
+
+    QTimer _assetsListChangedTimer;
 
 #ifdef BEAM_ASSET_SWAP_SUPPORT
     QVector<beam::Asset::ID> _allowedAssets;

--- a/ui/view/receive_regular.qml
+++ b/ui/view/receive_regular.qml
@@ -45,6 +45,13 @@ ColumnLayout {
         syncIdx()
     }
 
+    Connections {
+        target: viewModel
+        // The asset list can grow (held assets -> full on-chain list) while an
+        // asset is selected; re-map the selection by asset id so it stays put.
+        function onAssetsListChanged() { control.syncIdx() }
+    }
+
     Component.onCompleted: function () {
         // asset id might be passed by other parts of the UI as a parameter to the receive view
         syncIdx()
@@ -151,7 +158,9 @@ ColumnLayout {
                             id:          amountInput
                             amount:      viewModel.amount
                             currencies:  viewModel.assetsList
-                            multi:       viewModel.assetsList.length > 1
+                            // Always enable the picker so any on-chain CA can be
+                            // requested, even in a wallet that only holds BEAM.
+                            multi:       true
                             resetAmount: false
 
                            onCurrencyIdxChanged: function () {

--- a/ui/viewmodel/receive_view.cpp
+++ b/ui/viewmodel/receive_view.cpp
@@ -26,6 +26,13 @@ ReceiveViewModel::ReceiveViewModel()
 
     connect(_walletModel, &WalletModel::newAddressFailed, this, &ReceiveViewModel::newAddressFailed);
     connect(_amgr.get(), &AssetsManager::assetsListChanged, this, &ReceiveViewModel::assetsListChanged);
+    connect(_walletModel, &WalletModel::fullAssetsListLoaded, this, [this] () {
+        _fullAssetsList = true;
+        emit assetsListChanged();
+    });
+    // Load the full on-chain asset list in the background so any CA can be
+    // requested; until it arrives the wallet's own assets are shown.
+    _walletModel->getAsync()->loadFullAssetsList();
     updateToken(); // default address
 }
 
@@ -277,7 +284,10 @@ int ReceiveViewModel::getMPTimeLimit() const
 
 QList<QMap<QString, QVariant>> ReceiveViewModel::getAssetsList() const
 {
-    return _amgr->getAssetsList();
+    // Show the full on-chain list (so a CA can be requested even if the wallet
+    // doesn't hold it) once it has loaded; until then show the wallet's own
+    // assets so the picker is populated immediately.
+    return _fullAssetsList ? _amgr->getAssetsListFull() : _amgr->getAssetsList();
 }
 
 void ReceiveViewModel::setAssetId(int value)

--- a/ui/viewmodel/receive_view.h
+++ b/ui/viewmodel/receive_view.h
@@ -83,4 +83,5 @@ private:
     ExchangeRatesManager::Ptr _rates;
     AssetsManager::Ptr    _amgr;
     bool _newAddress = false;
+    bool _fullAssetsList = false;
 };


### PR DESCRIPTION
Fixes #1176.

### Problem
On the Receive screen, the "requested amount" asset picker only listed assets the wallet already held (`getAssetsNZ()` — non-zero balance). A confidential asset could not be requested unless you already owned it.

### Changes
- **Show all on-chain assets in the receive picker.** The receive view now loads the full on-chain asset list (`getAssetsListFull()`) in the background when it opens, falling back to the wallet's held assets as an instant placeholder until the list arrives. The picker is always enabled so a CA can be chosen even in a BEAM-only wallet, and the current selection is re-mapped by asset id when the list grows.
- **Coalesce asset-list updates.** `AssetsManager::onAssetInfo` previously emitted `assetsListChanged` on every asset-info reply. Rebuilding the full ~200-asset list once per reply is O(N²) and froze the UI while a burst of replies drained (e.g. navigating away with the dropdown open). The signal is now debounced through a 100 ms single-shot timer so a burst collapses into one rebuild. This benefits every consumer of the list (send, settings, asset swap).

### Testing
Built and verified in a Release build: the receive picker lists all on-chain assets, a non-held CA can be selected by typing its AID into the search box, BEAM remains the default, the Send picker is unchanged, and navigating away with the dropdown open no longer hangs.