### PR TITLE
#1263: Build Linux AppImage with modern appimagetool and zsync updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,9 +298,6 @@ jobs:
       - name: Sign AppImage [ubuntu]
         if: startsWith(matrix.os, 'ubuntu')
         env:
-          # appimagetool self-mounts via FUSE; extract-and-run avoids requiring
-          # FUSE for the tools themselves in CI. ARCH is required by appimagetool.
-          APPIMAGE_EXTRACT_AND_RUN: "1"
           ARCH: x86_64
         run: |
           mkdir signing
@@ -312,16 +309,15 @@ jobs:
           cp ../Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage .
           # Extract, sign and repack under the final release name, embedding zsync
           # update info (also emits the matching .zsync next to the AppImage).
+          # appimagetool self-mounts via FUSE; extract-and-run avoids needing it.
           ./Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-extract
-          ./appimagetool-x86_64.AppImage \
+          APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-x86_64.AppImage \
             --sign \
             -u "gh-releases-zsync|BeamMW|beam-ui|latest|*x86_64.AppImage.zsync" \
             squashfs-root \
             ../Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
-          # Output signature
           cd ..
           chmod a+x Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
-          ./Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-signature
 
       - name: Collect [ubuntu]
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,16 +308,22 @@ jobs:
           sudo chmod +x appimagetool-x86_64.AppImage
           cp ../Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage .
           # Extract, sign and repack under the final release name, embedding zsync
-          # update info (also emits the matching .zsync next to the AppImage).
+          # update info. appimagetool emits the matching .zsync next to the AppImage
+          # (in the current dir), so pack in place here and move both up together —
+          # writing the AppImage to ../ would leave the .zsync behind in signing/.
           # appimagetool self-mounts via FUSE; extract-and-run avoids needing it.
           ./Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-extract
           APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-x86_64.AppImage \
             --sign \
             -u "gh-releases-zsync|BeamMW|beam-ui|latest|*x86_64.AppImage.zsync" \
             squashfs-root \
-            ../Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
+            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
           cd ..
+          mv signing/Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage* .
           chmod a+x Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
+          # Fail loudly if the .zsync went missing (upload's if-no-files-found only
+          # errors when *no* path matches, not when one of several is absent).
+          ls Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage.zsync
 
       - name: Collect [ubuntu]
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,26 +297,36 @@ jobs:
 
       - name: Sign AppImage [ubuntu]
         if: startsWith(matrix.os, 'ubuntu')
+        env:
+          # appimagetool self-mounts via FUSE; extract-and-run avoids requiring
+          # FUSE for the tools themselves in CI. ARCH is required by appimagetool.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          ARCH: x86_64
         run: |
           mkdir signing
           cd signing
-          # Download AppImageTool
-          wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          # Download appimagetool. The old AppImageKit build embeds a runtime that
+          # needs libfuse2 at runtime; the modern appimagetool embeds a static one.
+          wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           sudo chmod +x appimagetool-x86_64.AppImage
           cp ../Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage .
-          # Extract, sign and pack AppImage
+          # Extract, sign and repack under the final release name, embedding zsync
+          # update info (also emits the matching .zsync next to the AppImage).
           ./Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-extract
-          ./appimagetool-x86_64.AppImage squashfs-root --sign
-          mv Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-x86_64.AppImage ../Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage
+          ./appimagetool-x86_64.AppImage \
+            --sign \
+            -u "gh-releases-zsync|BeamMW|beam-ui|latest|*x86_64.AppImage.zsync" \
+            squashfs-root \
+            ../Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
           # Output signature
-          ../Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-signature
+          cd ..
+          chmod a+x Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
+          ./Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage --appimage-signature
 
       - name: Collect [ubuntu]
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          cp Beam_Wallet${{env.BEAM_DISPLAY_SUFFIX4}}-${{env.BEAM_VERSION}}-x86_64.AppImage Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage
-          sha256sum Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage > Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage-checksum.txt
-          chmod a+x Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage
+          sha256sum Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage > Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage-checksum.txt
 
       - name: Collect [windows]
         if: startsWith(matrix.os, 'windows')
@@ -341,8 +351,9 @@ jobs:
         with:
           name: ${{env.PACKAGE_NAME}}-Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}
           path: |
-            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage
-            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}.AppImage-checksum.txt
+            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage
+            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage.zsync
+            Beam-Wallet${{env.BEAM_DISPLAY_SUFFIX2}}-${{env.BEAM_VERSION}}-x86_64.AppImage-checksum.txt
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Addresses #1263.

### Context
The Linux AppImage is currently packed/signed with the obsolete `AppImageKit` appimagetool, whose embedded runtime requires **libfuse2** at runtime — a library that is no longer maintained (since 2019) and no longer shipped by default on many distributions. The issue reporter (@ivan-hc, maintainer of the [AM](https://github.com/ivan-hc/AM) AppImage package manager) recommended migrating to the modern `AppImage/appimagetool`.

### Changes (`.github/workflows/build.yml`)
- **Migrate to the modern `appimagetool`.** The *Sign AppImage* step now downloads from `AppImage/appimagetool` (continuous) instead of `AppImage/AppImageKit`, so the embedded runtime is the modern static one and end users no longer need libfuse2. The new tool requires `ARCH=x86_64`, and `APPIMAGE_EXTRACT_AND_RUN=1` is set to avoid FUSE self-mount issues for the tooling in CI.
- **zsync delta updates.** `appimagetool` now packs with `-u "gh-releases-zsync|BeamMW|beam-ui|latest|*x86_64.AppImage.zsync"`, emitting a `.zsync` so clients can perform delta updates of the ~200 MB image. The `.zsync` is added to the uploaded artifact.
- **`-x86_64` asset naming.** The published AppImage (and its checksum/zsync) is now named `Beam-Wallet…-<version>-x86_64.AppImage`. A `.zsync` is bound to the exact filename it is generated against, so the AppImage is now produced directly under its final name in the Sign step rather than being renamed afterward. This `-x86_64` suffix is per @ivan-hc's recommendation and also aligns with the AM install script, which selects the x86_64 asset by matching on `x86_64`.

### Not included (manual release step)
Releases are published manually, so shipping the **raw `.AppImage`** on the GitHub Release (rather than the CI artifact `.zip`) remains a manual step. This workflow now provides the raw `.AppImage`, its `.zsync`, and the checksum in the artifact so they can be attached directly.

### Verification
CI-only change — verification is the `Build` workflow's ubuntu job completing through the AppImage → Sign → Collect steps. The libfuse2-free runtime behaviour is a property of the new appimagetool and is validated on end-user machines rather than by the build itself.