### PR TITLE
Contract price oracle: USD-only rates, per-asset USD, dual send input

### DIFF
--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -1499,11 +1499,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Актыў усё яшчэ заблакаваны</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Паказаць сумы ў</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Даступная новая версія %1</translation>
@@ -3964,6 +3959,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не ўдалося распакаваць файлы DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -1499,11 +1499,6 @@ znát všechny Vaše prostředky (UTXO). Ujistěte se, že jste vystavili klíč
         <source>Asset is still locked</source>
         <translation>Aktivum je stále uzamčeno</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Zobrazit částky v</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Nová verze %1 je k dispozici!</translation>
@@ -3964,6 +3959,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Soubory DApp se nepodařilo rozbalit.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -1494,11 +1494,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Asset ist noch gesperrt</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Zeige Guthaben in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Neue Version %s ist verfügbar</translation>
@@ -3949,6 +3944,11 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Die DApp-Dateien konnten nicht entpackt werden.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -1495,11 +1495,6 @@ deploy the key at the node you trust completely.</translation>
         <source>Asset is still locked</source>
         <translation>Asset is still locked</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>New version v %1 is available</translation>
@@ -3953,6 +3948,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Couldn&apos;t extract the DApp files.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation>Oracle price</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -1497,11 +1497,6 @@ despliegue la clave en el nodo en el que confía completamente.</translation>
         <source>Asset is still locked</source>
         <translation>Activo todavía está bloqueado</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Mostrar cantidades en</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>La nueva versión v %1 está disponible</translation>
@@ -3953,6 +3948,11 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>No se pudieron extraer los archivos de la DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -1497,11 +1497,6 @@ avaimen palvelimeen (node), johon luotat täysin.</translation>
         <source>Asset is still locked</source>
         <translation type="unfinished">Asset is still locked</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation type="unfinished">Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation type="unfinished">New version v %1 is available</translation>
@@ -3955,6 +3950,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp-tiedostoja ei voitu purkaa.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -1494,11 +1494,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>L&apos;actif est encore verrouillé</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Afficher les montants en</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Nouvelle version v %1 disponible</translation>
@@ -3926,7 +3921,7 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-cant-open">
         <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
-        <translation>Impossible d'ouvrir le fichier DApp. Il est peut-être corrompu.</translation>
+        <translation>Impossible d&apos;ouvrir le fichier DApp. Il est peut-être corrompu.</translation>
     </message>
     <message id="dapp-install-err-cant-read-manifest">
         <source>Couldn&apos;t read the DApp manifest.</source>
@@ -3934,7 +3929,7 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-unsupported">
         <source>This DApp is not supported by your wallet version.</source>
-        <translation>Cette DApp n'est pas prise en charge par votre version du portefeuille.</translation>
+        <translation>Cette DApp n&apos;est pas prise en charge par votre version du portefeuille.</translation>
     </message>
     <message id="dapp-install-err-invalid">
         <source>Invalid DApp file: the manifest is missing or incomplete.</source>
@@ -3946,11 +3941,16 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-folder">
         <source>Couldn&apos;t prepare the installation folder.</source>
-        <translation>Impossible de préparer le dossier d'installation.</translation>
+        <translation>Impossible de préparer le dossier d&apos;installation.</translation>
     </message>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
-        <translation>Impossible d'extraire les fichiers de la DApp.</translation>
+        <translation>Impossible d&apos;extraire les fichiers de la DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -1494,11 +1494,6 @@ menggunakan kunci tersebut pada node yang Anda percayai sepenuhnya.</translation
         <source>Asset is still locked</source>
         <translation>Aset masih terkunci</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Tampilkan jumlah dalam</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Versi baru v %1 tersedia</translation>
@@ -3945,6 +3940,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Tidak dapat mengekstrak berkas DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -1496,11 +1496,6 @@ distribuisca la chiave al nodo che ti fidi completamente.</translation>
         <source>Asset is still locked</source>
         <translation>L&apos;asset è ancora bloccato</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Mostra importi in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>La nuova versione v %1 è disponibile</translation>
@@ -3953,6 +3948,11 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Impossibile estrarre i file della DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -1489,11 +1489,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>アセットはまだロックされています</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>金額を表示する</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>新しいバージョンv %1が利用可能です。</translation>
@@ -3922,6 +3917,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DAppファイルを展開できませんでした。</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -1493,11 +1493,6 @@ deploy the key at the node you trust completely.</translation>
         <source>Asset is still locked</source>
         <translation type="unfinished">Asset is still locked</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation type="unfinished">Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation type="unfinished">New version v %1 is available</translation>
@@ -3945,6 +3940,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp 파일의 압축을 풀 수 없습니다.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -1495,11 +1495,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Asset is nog vergrendeld</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Toon bedragen in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Nieuwe versie v %1 is beschikbaar</translation>
@@ -3950,6 +3945,11 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Kan de DApp-bestanden niet uitpakken.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -1496,11 +1496,6 @@ implante a sua chave apenas em nó em que você confia completamente.</translati
         <source>Asset is still locked</source>
         <translation>O ativo ainda está bloqueado</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Mostrar valores em</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Nova versão v %1 está disponível</translation>
@@ -3952,6 +3947,11 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Não foi possível extrair os arquivos da DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -1499,11 +1499,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Актив по-прежнему заблокирован</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Показать суммы в</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Доступна новая версия v %1</translation>
@@ -3966,6 +3961,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не удалось распаковать файлы DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -1506,11 +1506,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Асет је још увек закључан</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation type="unfinished">Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation type="unfinished">New version v %1 is available</translation>
@@ -3977,6 +3972,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Nije moguće raspakovati DApp datoteke.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -1493,11 +1493,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Tillgången är fortfarande låst</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Visa belopp i</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Ny version v %1 är tillgänglig</translation>
@@ -3951,6 +3946,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Det gick inte att extrahera DApp-filerna.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -1494,11 +1494,6 @@ deploy the key at the node you trust completely.</translation>
         <source>Asset is still locked</source>
         <translation>สินทรัพย์ยังคงถูกล็อคไว้</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>แสดงยอดเงิน</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>พบเวอร์ชั่นใหม่หมายเลข %1 พร้อมให้ใช้งาน</translation>
@@ -3945,6 +3940,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>ไม่สามารถแตกไฟล์ DApp ได้</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -1493,11 +1493,6 @@ deploy the key at the node you trust completely.</translation>
         <source>Asset is still locked</source>
         <translation type="unfinished">Asset is still locked</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation type="unfinished">Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation type="unfinished">New version v %1 is available</translation>
@@ -3945,6 +3940,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp dosyaları çıkarılamadı.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -1499,11 +1499,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>Актив все ще заблокований</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>Показати суму в</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>Нова версія v %1 доступна</translation>
@@ -3961,6 +3956,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не вдалося розпакувати файли DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -1499,11 +1499,6 @@ deploy the key at the node you trust completely.</translation>
         <source>Asset is still locked</source>
         <translation type="unfinished">Asset is still locked</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation type="unfinished">Show amounts in</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation type="unfinished">New version v %1 is available</translation>
@@ -3958,6 +3953,11 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Không thể giải nén các tệp DApp.</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -1503,11 +1503,6 @@ deploy the key at the node you trust completely.</source>
         <source>Asset is still locked</source>
         <translation>资产仍被锁定</translation>
     </message>
-    <message id="settings-general-amounts-unit">
-        <source>Show amounts in</source>
-        <extracomment>settings tab, general section, amounts unit label</extracomment>
-        <translation>显示金额</translation>
-    </message>
     <message id="notification-update-title">
         <source>New version v %1 is available</source>
         <translation>新版本 v %1 可用</translation>
@@ -3961,6 +3956,11 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>无法解压 DApp 文件。</translation>
+    </message>
+    <message id="settings-oracle-price">
+        <source>Oracle price</source>
+        <extracomment>settings tab, header oracle price label</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/model/exchange_rates_manager.cpp
+++ b/ui/model/exchange_rates_manager.cpp
@@ -24,40 +24,14 @@
 ExchangeRatesManager::ExchangeRatesManager(WalletModel::Ptr wallet, WalletSettings& settings)
     : _wallet(std::move(wallet))
     , _settings(settings)
+    , m_rateUnit(beam::wallet::Currency::USD())
     , m_updateTime(0)
 {
-
     qRegisterMetaType<std::vector<beam::wallet::ExchangeRate>>("std::vector<beam::wallet::ExchangeRate>");
-
     connect(_wallet,
             SIGNAL(exchangeRatesUpdate(const std::vector<beam::wallet::ExchangeRate>&)),
             SLOT(onExchangeRatesUpdate(const std::vector<beam::wallet::ExchangeRate>&)));
-
-    connect(&_settings,
-            SIGNAL(secondCurrencyChanged()),
-            SLOT(onRateUnitChanged()));
-
-    m_rateUnit = _settings.getRateCurrency();
-    if (m_rateUnit != beam::wallet::Currency::UNKNOWN())
-    {
-        _wallet->getAsync()->getExchangeRates();
-    }
-}
-
-void ExchangeRatesManager::setRateUnit()
-{
-    auto newCurrency = _settings.getRateCurrency();
-    if (m_rateUnit == newCurrency)
-        return;
-
-    auto turnedOn = newCurrency != beam::wallet::Currency::UNKNOWN();
-    _wallet->getAsync()->switchOnOffExchangeRates(turnedOn);
-    if (turnedOn)
-    {
-        _wallet->getAsync()->getExchangeRates();
-    }
-    m_rateUnit = newCurrency;
-    setUpdateTime(0);
+    _wallet->getAsync()->getExchangeRates();
 }
 
 void ExchangeRatesManager::setUpdateTime(beam::Timestamp value)
@@ -77,8 +51,6 @@ bool ExchangeRatesManager::isUpToDate() const
 
 void ExchangeRatesManager::onExchangeRatesUpdate(const std::vector<beam::wallet::ExchangeRate>& rates)
 {
-    if (m_rateUnit == beam::wallet::Currency::UNKNOWN()) return;  /// Second currency is turned OFF
-
     bool isActiveRateChanged = false;
     for (const auto& rate : rates)
     {
@@ -98,12 +70,6 @@ void ExchangeRatesManager::onExchangeRatesUpdate(const std::vector<beam::wallet:
     {
         emit activeRateChanged();
     }
-}
-
-void ExchangeRatesManager::onRateUnitChanged()
-{
-    setRateUnit();
-    emit rateUnitChanged();
 }
 
 beam::wallet::Currency ExchangeRatesManager::getRateCurrency() const

--- a/ui/model/exchange_rates_manager.cpp
+++ b/ui/model/exchange_rates_manager.cpp
@@ -51,23 +51,23 @@ bool ExchangeRatesManager::isUpToDate() const
 
 void ExchangeRatesManager::onExchangeRatesUpdate(const std::vector<beam::wallet::ExchangeRate>& rates)
 {
-    bool isActiveRateChanged = false;
+    std::map<beam::wallet::Currency, beam::Amount> newRates;
     for (const auto& rate : rates)
     {
-        if (rate.m_to != m_rateUnit) 
+        if (rate.m_to != m_rateUnit)
             continue;
 
-        m_rates[rate.m_from] = rate.m_rate;
+        newRates[rate.m_from] = rate.m_rate;
         if (m_updateTime < rate.m_updateTime)
         {
             m_updateTime = rate.m_updateTime;
             emit updateTimeChanged();
         }
-        isActiveRateChanged = true;
     }
 
-    if (isActiveRateChanged)
+    if (newRates != m_rates)
     {
+        m_rates = std::move(newRates);
         emit activeRateChanged();
     }
 }

--- a/ui/model/exchange_rates_manager.h
+++ b/ui/model/exchange_rates_manager.h
@@ -35,7 +35,6 @@ public:
 
 public slots:
     void onExchangeRatesUpdate(const std::vector<beam::wallet::ExchangeRate>& rates);
-    void onRateUnitChanged();
 
 signals:
     void rateUnitChanged();
@@ -43,13 +42,12 @@ signals:
     void updateTimeChanged();
 
 private:
-    void setRateUnit();
     void setUpdateTime(beam::Timestamp value);
 
     WalletModel::Ptr _wallet;
     WalletSettings& _settings;
 
-    beam::wallet::Currency m_rateUnit = beam::wallet::Currency::UNKNOWN();
+    beam::wallet::Currency m_rateUnit = beam::wallet::Currency::USD();
     std::map<beam::wallet::Currency, beam::Amount> m_rates;
     beam::Timestamp m_updateTime;
 };

--- a/ui/model/settings.cpp
+++ b/ui/model/settings.cpp
@@ -126,10 +126,7 @@ namespace
     const std::vector<beam::wallet::Currency>& getSupportedRateUnits()
     {
         static const std::vector<beam::wallet::Currency> supportedUnits {
-            beam::wallet::Currency::UNKNOWN(),
-            beam::wallet::Currency::USD(),
-            beam::wallet::Currency::BTC(),
-            beam::wallet::Currency::ETH()
+            beam::wallet::Currency::USD()
         };
         return supportedUnits;
     }

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -31,8 +31,33 @@ ColumnLayout {
         RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignCenter | Qt.AlignRight
+
+            // fill spacer keeps the height/version group right-aligned (moved off the height label
+            // so the Oracle price can sit immediately to its left).
+            Item { Layout.fillWidth: true }
+
             SFText {
-                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignRight
+                visible: viewModel.oraclePrice.length > 0
+                //: settings tab, header oracle price label
+                //% "Oracle price"
+                text: qsTrId("settings-oracle-price")
+                color: Style.content_secondary
+                font.pixelSize: 14
+            }
+
+            SFLabel {
+                horizontalAlignment: Text.AlignRight
+                Layout.rightMargin: 20
+                visible: viewModel.oraclePrice.length > 0
+                color: Style.content_main
+                text: viewModel.oraclePrice
+                font.pixelSize: 14
+                font.styleName:      "Bold"
+                font.weight:         Font.Bold
+            }
+
+            SFText {
                 horizontalAlignment: Text.AlignRight
                 //% "Blockchain height"
                 text: qsTrId("settings-blockchain-height")

--- a/ui/view/controls/AmountInput.qml
+++ b/ui/view/controls/AmountInput.qml
@@ -15,6 +15,9 @@ ColumnLayout {
 
     function clearFocus() {
         ainput.focus = false
+        secondInput.focus = false
+        control.activeFieldIsSecond = false   // clear BEFORE amount so the USD row re-derives
+        secondInput.userText = ""
     }
 
     property var               currencies
@@ -40,7 +43,7 @@ ColumnLayout {
     property bool     resetAmount:  true
     property var      amountInput:  ainput
     property bool     showRate:     control.rateUnit != "" && control.rateUnit != control.currencyUnitNoId
-    readonly property bool isExchangeRateAvailable: control.rate != "0"
+    readonly property bool isExchangeRateAvailable: control.rate !== "0" && control.rate !== "-" && control.rate !== ""
     property alias    filterAssets: currCombo.filterAssets
     property bool     activeFieldIsSecond: false
 
@@ -187,6 +190,8 @@ ColumnLayout {
 
                     onActivated: function(index) {
                         if (multi) {
+                            control.activeFieldIsSecond = false   // clear BEFORE amount so the USD row re-derives
+                            secondInput.userText = ""
                             ainput.text = "0"
                             control.amount = "0"
                             control.currencyIdx = index
@@ -245,19 +250,25 @@ ColumnLayout {
                                           ? BeamGlobals.calcAmountInSecondCurrency(control.amount, control.rate, control.rateUnit)
                                           : "")
                     onTextEdited: {
-                        control.activeFieldIsSecond = true
+                        // save the typed text BEFORE flipping the flag, otherwise the live text
+                        // binding re-evaluates against the old (empty) userText and loses the first char
                         secondInput.userText = secondInput.text
-                        control.amount = Utils.calcAmountFromSecondCurrency(secondInput.text, control.rate, currencies[currencyIdx].decimals)
+                        control.activeFieldIsSecond = true
+                        control.amount = Utils.calcAmountFromSecondCurrency(secondInput.userText, control.rate, currencies[currencyIdx].decimals)
+                    }
+                    // re-derive the USD display only when BEAM (not this field) is the active driver;
+                    // the guard preserves the sub-cent behaviour (while USD drives, echo userText verbatim)
+                    function refreshFromPrimary() {
+                        if (!control.activeFieldIsSecond)
+                            secondInput.text = control.isExchangeRateAvailable
+                                ? BeamGlobals.calcAmountInSecondCurrency(control.amount, control.rate, control.rateUnit)
+                                : ""
                     }
                     Connections {
                         target: control
-                        function onAmountChanged() {
-                            // re-derive the USD display only when BEAM (not this field) is the active driver
-                            if (!control.activeFieldIsSecond)
-                                secondInput.text = control.isExchangeRateAvailable
-                                    ? BeamGlobals.calcAmountInSecondCurrency(control.amount, control.rate, control.rateUnit)
-                                    : ""
-                        }
+                        function onAmountChanged()   { secondInput.refreshFromPrimary() }
+                        function onRateChanged()     { secondInput.refreshFromPrimary() }
+                        function onRateUnitChanged() { secondInput.refreshFromPrimary() }
                     }
                 }
                 SFText {

--- a/ui/view/controls/AmountInput.qml
+++ b/ui/view/controls/AmountInput.qml
@@ -22,7 +22,7 @@ ColumnLayout {
 
     property int                currencyIdx:   currCombo.currentIndex
     readonly property string    currencyUnitNoId:  currencies[currencyIdx].unitName
-    readonly property string    currencyUnit:  currencies[currencyIdx].unitName + 
+    readonly property string    currencyUnit:  currencies[currencyIdx].unitName +
                                     ((currencies[currencyIdx].assetId > 0) ? " (%1)".arg(currencies[currencyIdx].assetId) : "")
     readonly property bool      isBeam:        !!currencies[currencyIdx].isBEAM
 
@@ -42,6 +42,11 @@ ColumnLayout {
     property bool     showRate:     control.rateUnit != "" && control.rateUnit != control.currencyUnitNoId
     readonly property bool isExchangeRateAvailable: control.rate != "0"
     property alias    filterAssets: currCombo.filterAssets
+    property bool     activeFieldIsSecond: false
+
+    // the editable USD row stays inside the box whenever a rate is available (kept on error too,
+    // so the field doesn't change shape when insufficient-funds validation kicks in)
+    readonly property bool showSecond: control.showRate && control.isExchangeRateAvailable
 
     SFText {
         font.pixelSize:   14
@@ -52,119 +57,6 @@ ColumnLayout {
         visible:          text.length > 0
     }
 
-    Item {
-        Layout.fillWidth: true
-        implicitHeight: ainput.implicitHeight
-
-        SFTextInput {
-            id:               ainput
-            anchors.left:     parent.left
-            anchors.right:    parent.right
-            font.pixelSize:   36
-            font.styleName:   "Light"
-            font.weight:      Font.Light
-            color:            !isValid ? Style.validator_error : control.color
-            backgroundColor:  !isValid ? Style.validator_error : Style.content_main
-            validator:        RegularExpressionValidator {regularExpression: new RegExp(ainput.getRegExpPattern())}
-            text:             formatDisplayedAmount()
-            readOnly:         control.readOnlyA
-            rightPadding:     currCombo.width
-
-            function stripAmountText() {
-                return text ? text.replace(/\.0*$|(\.\d*[1-9])0+$/,'$1') : "0"
-            }
-
-            onTextChanged: {
-                // if nothing then "0", remove insignificant zeroes and "." in floats
-                if (ainput.activeFocus) {
-                    control.amount = stripAmountText()
-                }
-            }
-
-            onActiveFocusChanged: {
-                text = formatDisplayedAmount()
-                if (activeFocus) cursorPosition = positionAt(ainput.getMousePos().x, ainput.getMousePos().y)
-            }
-
-            function formatDisplayedAmount() {
-                if (control.amount == "0") {
-                    return ainput.activeFocus ? "": "0"
-                }
-                return ainput.activeFocus ? control.amount : Utils.uiStringToLocale(control.amount)
-            }
-
-            function getRegExpPattern() {
-                // Allow integers up to 12 digits (max safe for uint64 with 8 decimals).
-                // Exact overflow protection is handled by the C++ backend (decode_base10)
-                // and the isEnoughAmount / balance validation.
-                var pattern = "^([1-9][0-9]{0,11}|0)(\\.[0-9]{0,%1}[1-9])?$";
-                return pattern.arg(currencies[currencyIdx].decimals - 1);
-            }
-
-            Connections {
-                target: control
-                function onAmountChanged () {
-                    var formatted = ainput.formatDisplayedAmount()
-
-                    if (!ainput.activeFocus)
-                    {
-                        ainput.text = formatted
-                    }
-                    else {
-                        if (formatted && formatted != ainput.stripAmountText()) {
-                            // we tolerate only insignificants 0 at the end of floats
-                            // so if user entered 0.000100 we do not strip last 2 zeroes at the end while in focus
-                            BeamGlobals.fatal("Absolute value of the amount should not be changed while control is in focus")
-                        }
-                    }
-                }
-            }
-        }
-
-        CustomComboBox {
-            id:                  currCombo
-            x:                   ainput.width - currCombo.width
-            y:                   10
-            dropSpacing:         18
-            spacing:             0
-            fontPixelSize:       20
-            dropFontPixelSize:   14
-            currentIndex:        control.currencyIdx
-            color:               !isValid ? Style.validator_error : control.currColor
-            underlineColor:      "transparent"
-            enabled:             multi
-            colorConst:          true
-            model:               control.currencies
-            textRole:            "unitNameWithId"
-            textMaxLenDrop:      10
-            enableScroll:        true
-            showBackground:      false
-            leftPadding:         30
-            maxTextWidth:        100
-            dropDownIconSixe:    Qt.size(9, 5)
-            dropDownIconRightMargin: 14
-            //% "Enter asset name..."
-            searchPlaseholder: qsTrId("amount-input-asset-search")
-
-            onActivated: function(index) {
-                if (multi) {
-                    ainput.text = "0"
-                    control.amount = "0"
-                    control.currencyIdx = index
-                }
-            }
-
-            onModelChanged: {
-                // changing model resets index selection, restore
-                if (multi) currentIndex = control.currencyIdx
-            }
-
-            onHoveredChanged: {
-                ainput.highlight = currCombo.hovered;
-            }
-        }
-    }
-
     onCurrencyIdxChanged: {
         if (multi) {
             if (control.currencyIdx != currCombo.currentIndex) {
@@ -173,21 +65,218 @@ ColumnLayout {
         }
     }
 
-    //
-    // Second
-    //
-    SFText {
-        visible:        control.showRate && !errmsg.visible
-        font.pixelSize: 14
-        font.italic:    !isExchangeRateAvailable
-        opacity:        isExchangeRateAvailable ? 0.5 : 1
-        color:          Style.content_secondary
-        text:           {
-            if (isExchangeRateAvailable)
-                return getAmountInSecondCurrency()
-            //% "Exchange rate to %1 is not available"
-            return qsTrId("general-exchange-rate-not-available").arg(control.rateUnit)
+    // Single amount box: BEAM row + hairline divider + USD row (mock: one field, two sections).
+    Item {
+        Layout.fillWidth: true
+        implicitHeight: amountBox.implicitHeight
+
+        // one shared rounded background for the whole field (individual inputs are boxless)
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+            color: Style.content_main
+            opacity: (ainput.activeFocus || secondInput.activeFocus || ainput.hovered) ? 0.1 : 0.05
         }
+
+        ColumnLayout {
+            id: amountBox
+            anchors.fill: parent
+            spacing: 0
+
+            // ----- primary (BEAM/asset) row -----
+            Item {
+                Layout.fillWidth: true
+                Layout.leftMargin:  16
+                Layout.rightMargin: 8
+                implicitHeight: ainput.implicitHeight
+
+                SFTextInput {
+                    id:               ainput
+                    anchors.left:     parent.left
+                    anchors.right:    parent.right
+                    underlineVisible: false
+                    font.pixelSize:   36
+                    font.styleName:   "Light"
+                    font.weight:      Font.Light
+                    // accent when the BEAM field is active, gray when the USD field is
+                    color:            !isValid ? Style.validator_error : (control.activeFieldIsSecond ? Style.content_secondary : control.color)
+                    backgroundColor:  !isValid ? Style.validator_error : Style.content_main
+                    validator:        RegularExpressionValidator {regularExpression: new RegExp(ainput.getRegExpPattern())}
+                    text:             formatDisplayedAmount()
+                    readOnly:         control.readOnlyA
+                    rightPadding:     currCombo.width
+
+                    function stripAmountText() {
+                        return text ? text.replace(/\.0*$|(\.\d*[1-9])0+$/,'$1') : "0"
+                    }
+
+                    onTextChanged: {
+                        // if nothing then "0", remove insignificant zeroes and "." in floats
+                        if (ainput.activeFocus) {
+                            control.activeFieldIsSecond = false   // set BEFORE amount so the USD field re-derives
+                            control.amount = stripAmountText()
+                        }
+                    }
+
+                    onActiveFocusChanged: {
+                        text = formatDisplayedAmount()
+                        if (activeFocus) cursorPosition = positionAt(ainput.getMousePos().x, ainput.getMousePos().y)
+                    }
+
+                    function formatDisplayedAmount() {
+                        if (control.amount == "0") {
+                            return ainput.activeFocus ? "": "0"
+                        }
+                        return ainput.activeFocus ? control.amount : Utils.uiStringToLocale(control.amount)
+                    }
+
+                    function getRegExpPattern() {
+                        // Allow integers up to 12 digits (max safe for uint64 with 8 decimals).
+                        // Exact overflow protection is handled by the C++ backend (decode_base10)
+                        // and the isEnoughAmount / balance validation.
+                        var pattern = "^([1-9][0-9]{0,11}|0)(\\.[0-9]{0,%1}[1-9])?$";
+                        return pattern.arg(currencies[currencyIdx].decimals - 1);
+                    }
+
+                    Connections {
+                        target: control
+                        function onAmountChanged () {
+                            var formatted = ainput.formatDisplayedAmount()
+
+                            if (!ainput.activeFocus)
+                            {
+                                ainput.text = formatted
+                            }
+                            else {
+                                if (formatted && formatted != ainput.stripAmountText()) {
+                                    // we tolerate only insignificants 0 at the end of floats
+                                    // so if user entered 0.000100 we do not strip last 2 zeroes at the end while in focus
+                                    BeamGlobals.fatal("Absolute value of the amount should not be changed while control is in focus")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                CustomComboBox {
+                    id:                  currCombo
+                    x:                   ainput.width - currCombo.width
+                    y:                   10
+                    dropSpacing:         18
+                    spacing:             0
+                    fontPixelSize:       20
+                    dropFontPixelSize:   14
+                    currentIndex:        control.currencyIdx
+                    color:               !isValid ? Style.validator_error : control.currColor
+                    // coin icon/name dim to ~50% when the USD field is active
+                    opacity:             control.activeFieldIsSecond ? 0.5 : 1.0
+                    underlineColor:      "transparent"
+                    enabled:             multi
+                    colorConst:          true
+                    model:               control.currencies
+                    textRole:            "unitNameWithId"
+                    textMaxLenDrop:      10
+                    enableScroll:        true
+                    showBackground:      false
+                    leftPadding:         30
+                    maxTextWidth:        100
+                    dropDownIconSixe:    Qt.size(9, 5)
+                    dropDownIconRightMargin: 14
+                    //% "Enter asset name..."
+                    searchPlaseholder: qsTrId("amount-input-asset-search")
+
+                    onActivated: function(index) {
+                        if (multi) {
+                            ainput.text = "0"
+                            control.amount = "0"
+                            control.currencyIdx = index
+                        }
+                    }
+
+                    onModelChanged: {
+                        // changing model resets index selection, restore
+                        if (multi) currentIndex = control.currencyIdx
+                    }
+
+                    onHoveredChanged: {
+                        ainput.highlight = currCombo.hovered;
+                    }
+                }
+            }
+
+            // ----- hairline divider between the two sections -----
+            Rectangle {
+                visible:             control.showSecond
+                Layout.fillWidth:    true
+                Layout.leftMargin:   16
+                Layout.rightMargin:  16
+                implicitHeight:      1
+                color:               Style.content_secondary
+                opacity:             0.25
+            }
+
+            // ----- second (USD) row -----
+            RowLayout {
+                visible:            control.showSecond
+                Layout.fillWidth:   true
+                Layout.leftMargin:  16
+                Layout.rightMargin: 16
+                Layout.topMargin:   6
+                Layout.bottomMargin: 8
+                spacing:            6
+
+                SFTextInput {
+                    id:             secondInput
+                    property string userText: ""   // raw text the user typed; echoed verbatim while USD drives the amount
+                    underlineVisible: false
+                    Layout.fillWidth: true
+                    font.pixelSize: 14
+                    enabled:        control.isExchangeRateAvailable && !control.readOnlyA
+                    // accent when the USD field is active, gray otherwise
+                    color:          control.activeFieldIsSecond ? Style.accent_incoming : Style.content_secondary
+                    validator:      RegularExpressionValidator { regularExpression: /^[0-9]*[.,]?[0-9]*$/ }
+                    // While the USD field is the active driver, echo the user's own text verbatim. Do NOT
+                    // re-derive it from control.amount here: calcAmountInSecondCurrency re-rounds to USD's 2
+                    // decimals, so a sub-cent entry like "0.0001" would collapse to "0" the moment the BEAM
+                    // amount updates. When BEAM drives, show the converted (display) value.
+                    text:           control.activeFieldIsSecond
+                                      ? secondInput.userText
+                                      : (control.isExchangeRateAvailable
+                                          ? BeamGlobals.calcAmountInSecondCurrency(control.amount, control.rate, control.rateUnit)
+                                          : "")
+                    onTextEdited: {
+                        control.activeFieldIsSecond = true
+                        secondInput.userText = secondInput.text
+                        control.amount = Utils.calcAmountFromSecondCurrency(secondInput.text, control.rate, currencies[currencyIdx].decimals)
+                    }
+                    Connections {
+                        target: control
+                        function onAmountChanged() {
+                            // re-derive the USD display only when BEAM (not this field) is the active driver
+                            if (!control.activeFieldIsSecond)
+                                secondInput.text = control.isExchangeRateAvailable
+                                    ? BeamGlobals.calcAmountInSecondCurrency(control.amount, control.rate, control.rateUnit)
+                                    : ""
+                        }
+                    }
+                }
+                SFText {
+                    text:           control.rateUnit
+                    font.pixelSize: 14
+                    // "USD" turns white when the USD field is active, gray otherwise
+                    color:          control.activeFieldIsSecond ? Style.content_main : Style.content_secondary
+                }
+            }
+        }
+    }
+
+    SFText {
+        visible:        control.showRate && !errmsg.visible && !control.isExchangeRateAvailable
+        font.pixelSize: 14
+        font.italic:    true
+        color:          Style.content_secondary
+        //% "Exchange rate to %1 is not available"
+        text:           qsTrId("general-exchange-rate-not-available").arg(control.rateUnit)
     }
 
     //
@@ -195,6 +284,9 @@ ColumnLayout {
     //
     SFText {
         Layout.fillWidth:     true
+        Layout.leftMargin:    16   // align with the box content inset
+        Layout.rightMargin:   16
+        Layout.topMargin:     6
         id:                   errmsg
         color:                Style.validator_error
         font.pixelSize:       14

--- a/ui/view/controls/SettingsGeneral.qml
+++ b/ui/view/controls/SettingsGeneral.qml
@@ -7,6 +7,7 @@ import "."
 SettingsFoldable {
     id: generalBlock
     property var viewModel
+    readonly property int settingsControlWidth: 210
     //: settings tab, general section, title
     //% "General"
     title: qsTrId("settings-general-title")
@@ -33,7 +34,7 @@ SettingsFoldable {
             ColumnLayout {
                 LanguageComboBox {
                     id: language
-                    Layout.preferredWidth: secondCurrencySwitch.width
+                    Layout.preferredWidth: settingsControlWidth
                     languages:     viewModel.supportedLanguages
                     languageIndex: viewModel.currentLanguageIndex
                     onLanguageActivated: (language) => { viewModel.currentLanguage = language }
@@ -55,7 +56,7 @@ SettingsFoldable {
             CustomComboBox {
                 id: lockTimeoutControl
                 fontPixelSize: 14
-                Layout.preferredWidth: secondCurrencySwitch.width
+                Layout.preferredWidth: settingsControlWidth
                 currentIndex: viewModel.lockTimeout
                 model: [
                     //% "Never"
@@ -90,36 +91,11 @@ SettingsFoldable {
             CustomComboBox {
                 id: minConfirmationsControl
                 fontPixelSize: 14
-                Layout.preferredWidth: secondCurrencySwitch.width
+                Layout.preferredWidth: settingsControlWidth
                 currentIndex: viewModel.minConfirmations
                 model: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
                 onActivated: {
                     viewModel.minConfirmations = minConfirmationsControl.currentIndex
-                }
-            }
-        }
-
-        RowLayout {
-            SFText {
-                Layout.fillWidth: true
-                //: settings tab, general section, amounts unit label
-                //% "Show amounts in"
-                text: qsTrId("settings-general-amounts-unit")
-                color: Style.content_secondary
-                font.pixelSize: 14
-            }
-            Item {}
-            TristateSwitch {
-                id: secondCurrencySwitch
-                width: 210
-                height: 20
-                choices: ["usd", "btc", "eth"]
-                labels:  ["USD", "BTC", "ETH"]
-                state: viewModel.secondCurrency
-                Binding {
-                    target: viewModel
-                    property: "secondCurrency"
-                    value: secondCurrencySwitch.state
                 }
             }
         }

--- a/ui/view/utils.js
+++ b/ui/view/utils.js
@@ -58,6 +58,25 @@ function formatFeeToSecondCurrency(amount, exchangeRate, secondCurrLabel) {
     return formatSecondCurrency(convertedAmount, amount, exchangeRate, secondCurrLabel);
 }
 
+// second-currency amount -> primary (BEAM/asset) amount, "C"-locale string.
+// `decimals` = the PRIMARY currency's decimal count (asset the amount is denominated in).
+function calcAmountFromSecondCurrency(secondAmount, exchangeRate, decimals) {
+    if (exchangeRate === "" || exchangeRate === "0" || secondAmount === "")
+        return "0";
+    // The field's validator accepts a single '.' OR ',' as the decimal mark and forbids grouping,
+    // so treat BOTH as the decimal point by normalizing ',' -> '.'.  Do NOT use
+    // localeDecimalToCString here: in a comma-decimal locale it treats '.' as the GROUP separator
+    // and strips it, turning "0.0001" into "00001" (=1) -- the #844 input bug.
+    // divideWithPrecision throws (crashing QML) on ',' and on bare "." / "," -- the parseFloat
+    // guard rejects those incomplete inputs before we call it.
+    var clean = secondAmount.replace(/,/g, '.');
+    // Only a plain decimal (at most one '.') is safe for divideWithPrecision; reject anything
+    // else ("1.2.3", bare ".", non-numeric) so it can't throw. parseFloat rejects "" / ".".
+    if (!/^[0-9]*\.?[0-9]*$/.test(clean) || isNaN(parseFloat(clean)))
+        return "0";
+    return BeamGlobals.divideWithPrecision(clean, exchangeRate, decimals);
+}
+
 // @arg amount - any number or float string in "C" locale
 function uiStringToLocale (amount) {
     var locale = Qt.locale();

--- a/ui/viewmodel/asset_swap_accept_view.cpp
+++ b/ui/viewmodel/asset_swap_accept_view.cpp
@@ -220,8 +220,8 @@ QList<QMap<QString, QVariant>> AssetSwapAcceptViewModel::getCurrenciesList(
     info.insert("iconWidth",  22);
     info.insert("iconHeight", 22);
     info.insert("decimals",   static_cast<uint8_t>(std::log10(beam::Rules::Coin)));
-    info.insert("rate",       "-");
-    info.insert("rateUnit",   "-");
+    info.insert("rate",       "");
+    info.insert("rateUnit",   "");
 
     result.push_back(info);
 

--- a/ui/viewmodel/settings_view.cpp
+++ b/ui/viewmodel/settings_view.cpp
@@ -407,17 +407,12 @@ void SettingsViewModel::setCurrentLanguage(QString value)
 
 QString SettingsViewModel::getSecondCurrency() const
 {
-    return QString::fromStdString(m_rateCurrency.m_value);
+    return QString::fromStdString(beam::wallet::Currency::USD().m_value);
 }
 
-void SettingsViewModel::setSecondCurrency(const QString& value)
+void SettingsViewModel::setSecondCurrency(const QString&)
 {
-    const auto currency = beam::wallet::Currency(value.toStdString());
-
-    m_rateCurrency = currency;
-    m_settings.setRateCurrency(currency);
-
-    emit secondCurrencyChanged();
+    // USD-only: second-currency selection removed. No-op.
 }
 
 const QString& SettingsViewModel::getPublicAddress() const

--- a/ui/viewmodel/settings_view.cpp
+++ b/ui/viewmodel/settings_view.cpp
@@ -50,6 +50,7 @@ SettingsViewModel::SettingsViewModel()
     , m_supportedLanguages(WalletSettings::getSupportedLanguages())
     , m_rateCurrency(beam::wallet::Currency::UNKNOWN())
     , m_walletModel(AppModel::getInstance().getWalletModel())
+    , m_exchangeRatesManager(AppModel::getInstance().getRates())
 #ifdef BEAM_ASSET_SWAP_SUPPORT
     , m_amgr(AppModel::getInstance().getAssets())
 #endif  // BEAM_ASSET_SWAP_SUPPORT
@@ -68,6 +69,7 @@ SettingsViewModel::SettingsViewModel()
     connect(m_walletModel, SIGNAL(publicAddressChanged(const QString&)), SLOT(onPublicAddressChanged(const QString&)));
     connect(&m_settings, SIGNAL(beamMWLinksChanged()), SIGNAL(beamMWLinksPermissionChanged()));
     connect(m_walletModel, &WalletModel::walletStatusChanged, this, &SettingsViewModel::stateChanged);
+    connect(m_exchangeRatesManager.get(), &ExchangeRatesManager::activeRateChanged, this, &SettingsViewModel::oraclePriceChanged);
 
     m_timerId = startTimer(CHECK_INTERVAL);
 
@@ -371,6 +373,15 @@ void SettingsViewModel::allowBeamMWLinks(bool value)
 QString SettingsViewModel::getCurrentHeight() const
 {
     return QString::fromStdString(to_string(m_walletModel->getCurrentStateID().m_Height));
+}
+
+QString SettingsViewModel::getOraclePrice() const
+{
+    // BEAM/USD from the on-chain oracle. Empty when unavailable (blank over wrong).
+    auto rate = m_exchangeRatesManager->getRate(beam::wallet::Currency::BEAM());
+    if (!rate)
+        return QString();
+    return "$" + beamui::AmountToUIString(rate, beamui::Currencies::Unknown, false);
 }
 
 QStringList SettingsViewModel::getSupportedLanguages() const

--- a/ui/viewmodel/settings_view.h
+++ b/ui/viewmodel/settings_view.h
@@ -23,6 +23,7 @@
 #endif  // BEAM_ASSET_SWAP_SUPPORT
 
 #include "model/settings.h"
+#include "model/exchange_rates_manager.h"
 #include "wallet/transactions/swaps/bridges/bitcoin/client.h"
 #include "wallet/transactions/swaps/bridges/bitcoin/settings.h"
 #include "viewmodel/notifications/notifications_settings.h"
@@ -34,6 +35,7 @@ class SettingsViewModel : public QObject
 
     Q_PROPERTY(QString      nodeAddress                     READ getNodeAddress                 WRITE setNodeAddress    NOTIFY nodeAddressChanged)
     Q_PROPERTY(QString      version                         READ getVersion                     CONSTANT)
+    Q_PROPERTY(QString      oraclePrice                     READ getOraclePrice                 NOTIFY oraclePriceChanged)
     Q_PROPERTY(bool         connectLocalNode                READ getConnectLocalNode            WRITE setConnectLocalNode   NOTIFY connectLocalNodeChanged)
     Q_PROPERTY(bool         localNodeRun                    READ getLocalNodeRun                WRITE setLocalNodeRun   NOTIFY localNodeRunChanged)
     Q_PROPERTY(unsigned int localNodePort                   READ getLocalNodePort               WRITE setLocalNodePort  NOTIFY localNodePortChanged)
@@ -151,6 +153,7 @@ public:
     void setAppsPort(int port);
 
     QString getCurrentHeight() const;
+    QString getOraclePrice() const;
 
     Q_INVOKABLE uint coreAmount() const;
     Q_INVOKABLE void addLocalNodePeer(const QString& localNodePeer);
@@ -207,6 +210,7 @@ signals:
     void maxPrivacyLockTimeLimitChanged();
     void minConfirmationsChanged();
     void stateChanged();
+    void oraclePriceChanged();
     void appsPortChanged();
 
     #ifdef BEAM_IPFS_SUPPORT
@@ -258,6 +262,7 @@ private:
     mutable int m_mpAnonymitySetIndex = 0;
     mutable int m_mpLockTimeLimitIndex = 1;
     WalletModel::Ptr m_walletModel;
+    ExchangeRatesManager::Ptr m_exchangeRatesManager;
     const int CHECK_INTERVAL = 1000;
 
 #ifdef BEAM_ASSET_SWAP_SUPPORT


### PR DESCRIPTION
Consumes the on-chain oracle/AMM exchange rates from the beam submodule (companion PR BeamMW/beam#2069):

- Second currency is now **USD-only** — removes the BTC/ETH "Show amounts in" selector, which the USD-only backend can no longer price (`ExchangeRatesManager`, settings, `SettingsGeneral.qml`).
- **Per-asset USD** surfaces in the live UI (asset tiles + tx list) via the existing rate plumbing, now that the backend supplies the data.
- **Dual BEAM/USD amount input** on the send screen with two-way conversion (#844).
- Shows the **oracle BEAM/USD price** in the Settings header, next to the blockchain height.
- Drops the obsolete second-currency-selector translation string; adds the oracle-price string.

Closes #1217
Closes #1218
Closes #515
Closes #844

## Dependency

This PR depends on the beam submodule PR **BeamMW/beam#2069** and must **not** be merged until:

1. **BeamMW/beam#2069 is merged to `master`.**
2. This branch's `beam` submodule pointer is **updated to the beam `master` merge commit**. It currently points at the beam PR branch (`feat/oracle-wallet`) so this PR can be built, reviewed, and tested against the backend before that PR merges.

Only after the submodule is re-pointed to the merged `master` commit should this PR be merged.