### PR TITLE
Atomic swaps: restore offer publishing, UI fixes, generic Ethereum RPC settings, any-asset/any-token swaps

### DIFF
--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -3962,5 +3962,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -3958,5 +3958,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -918,14 +918,6 @@
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Сума атрымання</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Сума адпраўкі</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Абменны курс</translation>
@@ -2222,10 +2214,6 @@ much longer for a transaction to complete.</source>
 Please try again later or create an offer yourself.</source>
         <translation>На дадзены момант няма актыўных прапаноў.
 Паўтарыце спробу пазней альбо стварыце прапанову самастойна.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Адправіць</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3595,10 +3583,6 @@ Please, restart the wallet and try again.</source>
         <source>updating</source>
         <translation>абнаўленне</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Атрымаць</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Курс</translation>
@@ -3964,6 +3948,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не ўдалося распакаваць файлы DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -3975,7 +3975,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4004,6 +4005,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Токен</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -2066,8 +2066,9 @@ Your version is: %2. Please, check for updates.</source>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Вузел Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Вузел Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/be_BY.ts
+++ b/ui/i18n/be_BY.ts
@@ -4083,5 +4083,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -3958,5 +3958,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -3962,5 +3962,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -3975,7 +3975,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4004,6 +4005,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -2065,8 +2065,9 @@ Vaše verze je: %2. Zkontrolujte prosím aktualizace.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum node</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -4083,5 +4083,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/cs_CZ.ts
+++ b/ui/i18n/cs_CZ.ts
@@ -918,14 +918,6 @@
         <source>Password</source>
         <translation>Heslo</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Přijmout částku</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Odeslat částku</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Směnný kurz</translation>
@@ -2221,10 +2213,6 @@ Zkontrolujte na %1 blockchainu sami. Nízké poplatky mohou způsobit
 Please try again later or create an offer yourself.</source>
         <translation>Momentálně nejsou žádné aktivní nabídky.
 Zkuste to prosím později nebo vytvořte svou nabídku.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Odeslat</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3595,10 +3583,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>probíhá aktualizace</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Přijmout</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Sazba</translation>
@@ -3964,6 +3948,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Soubory DApp se nepodařilo rozbalit.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -2055,8 +2055,9 @@ erhalten (öffentlich offline)</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum Node</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereum Node</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -4068,5 +4068,9 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -915,14 +915,6 @@
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Betrag erhalten</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Betrag senden</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Wechselkurs</translation>
@@ -2211,10 +2203,6 @@ viel länger dauern, bis eine Transaktion abgeschlossen ist.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Momentan gibt es keine aktiven Angebote.
 Bitte versuchen Sie es später noch einmal oder erstellen Sie selbst ein Angebot.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Senden</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3580,10 +3568,6 @@ Bitte starten Sie das Wallet neu und versuchen Sie es erneut.</translation>
         <source>updating</source>
         <translation>aktualisiere</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Erhalten</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Rate</translation>
@@ -3949,6 +3933,14 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Die DApp-Dateien konnten nicht entpackt werden.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -3960,7 +3960,8 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3989,6 +3990,82 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -3943,5 +3943,9 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/de_DE.ts
+++ b/ui/i18n/de_DE.ts
@@ -3947,5 +3947,49 @@ Verbinden Sie Ihre Hardware-Wallet um die Transaktion abzuschließen.</translati
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Password</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Receive amount</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Send amount</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Exchange rate</translation>
@@ -2214,10 +2206,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>There are no active offers at the moment.
 Please try again later or create an offer yourself.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Send</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3612,10 +3600,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>updating</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Receive</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Rate</translation>
@@ -3953,6 +3937,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Couldn&apos;t extract the DApp files.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation>I send</translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation>I receive</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -2058,8 +2058,9 @@ Your version is: %2. Please, check for updates.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum node</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation>Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -3951,5 +3951,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation>Infura</translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation>Custom RPC</translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation>Ethereum RPC endpoint</translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation>Check connection</translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation>Unable to connect</translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation>Ethereum Mainnet</translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation>Sepolia Testnet</translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation>chain %1</translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation>Connected to %1. Latest block: %2</translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation>Connected to %1, but Ethereum Mainnet is required</translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -3947,5 +3947,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation>I receive</translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -4072,5 +4072,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation>This token is already supported</translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation>Not enough ETH to pay the redeem transaction fee (%1 needed)</translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/en_US.ts
+++ b/ui/i18n/en_US.ts
@@ -3964,8 +3964,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation>Ethereum RPC endpoint</translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
-        <translation type="unfinished"></translation>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
+        <translation>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</translation>
     </message>
     <message id="settings-eth-check-connection">
         <source>Check connection</source>
@@ -3994,6 +3995,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
         <translation>Connected to %1, but Ethereum Mainnet is required</translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation>Custom ERC-20 tokens</translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation>remove</translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation>0x contract address</translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation>Look up</translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation>Add</translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation>%1, %2 decimals</translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation>Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation>Contract address</translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation>Symbol / decimals</translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation>Verify this token contract address carefully. Anyone can create a token with any name.</translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation>Confidential Asset</translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation>Asset id %1, unit %2</translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation>Invalid contract address</translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation>built-in</translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation>+ Add token</translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation>cancel</translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
+        <translation>This token is already supported</translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -2060,8 +2060,9 @@ Su versión es: %2. Por favor, compruebe si hay actualizaciones.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Nodo de Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Nodo de Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -3947,5 +3947,9 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -3951,5 +3951,49 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -3964,7 +3964,8 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3993,6 +3994,82 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Recibir cantidad</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Enviar cantidad</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Tipo de cambio</translation>
@@ -2215,10 +2207,6 @@ Compruebe usted en la %1 blockchain. Las tarifas bajas pueden demorar mucho más
 Please try again later or create an offer yourself.</source>
         <translation>No hay ofertas activas en este momento.
 Por favor, inténtalo de nuevo más tarde o crea una oferta usted mismo.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Enviar</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3584,10 +3572,6 @@ Por favor, reinicie el wallet e inténtelo de nuevo.</translation>
         <source>updating</source>
         <translation>actualizando</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Recibe</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Valorar</translation>
@@ -3953,6 +3937,14 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>No se pudieron extraer los archivos de la DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/es_ES.ts
+++ b/ui/i18n/es_ES.ts
@@ -4072,5 +4072,9 @@ Conecte el Wallet Físico para finalizar la transacción.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -3949,5 +3949,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -3953,5 +3953,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Salasana</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Vastaanotettava summa</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Summa</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Vaihtokurssi</translation>
@@ -2216,10 +2208,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Ei yhtään voimassa olevaa tarjousta.
 Tee oma tarjous tai yritä myöhemmin uudelleen.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Lähetä</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3586,10 +3574,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>päivittää</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Vastaanota</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Vaihtomaksu</translation>
@@ -3955,6 +3939,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp-tiedostoja ei voitu purkaa.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -3966,7 +3966,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3995,6 +3996,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -4074,5 +4074,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fi_FI.ts
+++ b/ui/i18n/fi_FI.ts
@@ -2060,7 +2060,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -3945,5 +3945,9 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -2057,8 +2057,9 @@ Votre version est : %2. Veuillez vérifier les mises à jour.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Nœud Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Nœud Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Recevoir montant</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Envoyer montant</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Taux de change</translation>
@@ -2213,10 +2205,6 @@ prendre beaucoup plus de temps pour compléter une transaction.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Il n&apos;y a pas d&apos;offre active pour le moment.
 Veuillez réessayer plus tard ou créer une offre vous-même.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Envoyer</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3582,10 +3570,6 @@ Veuillez redémarrer le portefeuille et réessayer.</translation>
         <source>updating</source>
         <translation>mise à jour en cours</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Recevoir</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Taux</translation>
@@ -3926,7 +3910,7 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-cant-open">
         <source>Couldn&apos;t open the DApp file. It may be corrupted.</source>
-        <translation>Impossible d'ouvrir le fichier DApp. Il est peut-être corrompu.</translation>
+        <translation>Impossible d&apos;ouvrir le fichier DApp. Il est peut-être corrompu.</translation>
     </message>
     <message id="dapp-install-err-cant-read-manifest">
         <source>Couldn&apos;t read the DApp manifest.</source>
@@ -3934,7 +3918,7 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-unsupported">
         <source>This DApp is not supported by your wallet version.</source>
-        <translation>Cette DApp n'est pas prise en charge par votre version du portefeuille.</translation>
+        <translation>Cette DApp n&apos;est pas prise en charge par votre version du portefeuille.</translation>
     </message>
     <message id="dapp-install-err-invalid">
         <source>Invalid DApp file: the manifest is missing or incomplete.</source>
@@ -3946,11 +3930,19 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="dapp-install-err-folder">
         <source>Couldn&apos;t prepare the installation folder.</source>
-        <translation>Impossible de préparer le dossier d'installation.</translation>
+        <translation>Impossible de préparer le dossier d&apos;installation.</translation>
     </message>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
-        <translation>Impossible d'extraire les fichiers de la DApp.</translation>
+        <translation>Impossible d&apos;extraire les fichiers de la DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -4070,5 +4070,9 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -3949,5 +3949,49 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/fr_FR.ts
+++ b/ui/i18n/fr_FR.ts
@@ -3962,7 +3962,8 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3991,6 +3992,82 @@ Connectez votre portefeuille physique pour finaliser la transaction.</translatio
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Jeton</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -3939,5 +3939,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -2055,8 +2055,9 @@ Versi Anda adalah: %2. Silakan periksa pembaruan.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum node</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -4064,5 +4064,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -3956,7 +3956,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3985,6 +3986,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -915,14 +915,6 @@
         <source>Password</source>
         <translation>Kata sandi</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Jumlah yang diterima</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Jumlah kirim</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Kurs</translation>
@@ -2211,10 +2203,6 @@ lebih lama untuk menyelesaikan transaksi.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Tidak ada penawaran aktif saat ini.
 Silakan coba lagi nanti atau buat penawaran sendiri.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Kirim</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3577,10 +3565,6 @@ Silakan mulai ulang dompet dan coba lagi.</translation>
         <source>updating</source>
         <translation>memperbarui</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Terima</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Rate</translation>
@@ -3945,6 +3929,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Tidak dapat mengekstrak berkas DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/id_ID.ts
+++ b/ui/i18n/id_ID.ts
@@ -3943,5 +3943,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -3964,7 +3964,8 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3993,6 +3994,82 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Password</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Ricevi importo</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Inviare importo</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Tasso di cambio</translation>
@@ -2216,10 +2208,6 @@ molto più a lungo per completare una transazione.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Al momento non ci sono offerte attive.
 Riprova più tardi o crea un&apos;offerta.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Invia</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3584,10 +3572,6 @@ Riavviare il wallet e riprovare.</translation>
         <source>updating</source>
         <translation>in aggiornamento</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Ricevere</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Vota</translation>
@@ -3953,6 +3937,14 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Impossibile estrarre i file della DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -3947,5 +3947,9 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -2060,8 +2060,9 @@ fallito
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Nodo Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Nodo Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -4072,5 +4072,9 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/it_IT.ts
+++ b/ui/i18n/it_IT.ts
@@ -3951,5 +3951,49 @@ Collega il tuo wallet Hardware per finalizzare la transazione.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -4041,5 +4041,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -2040,8 +2040,9 @@ Your version is: %2. Please, check for updates.</source>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereumノード</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereumノード</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -913,14 +913,6 @@
         <source>Password</source>
         <translation>パスワード</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>受取り金額</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>送金額</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>交換レート</translation>
@@ -2194,10 +2186,6 @@ much longer for a transaction to complete.</source>
 Please try again later or create an offer yourself.</source>
         <translation>現在アクティブなオファーはありません。
 後でもう一度試すか、自分でオファーを作成してください。</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>送信</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3553,10 +3541,6 @@ Please, restart the wallet and try again.</source>
         <source>updating</source>
         <translation>更新中</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>受信</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>レート</translation>
@@ -3922,6 +3906,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DAppファイルを展開できませんでした。</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -3920,5 +3920,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -3916,5 +3916,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ja_JP.ts
+++ b/ui/i18n/ja_JP.ts
@@ -3933,7 +3933,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3962,6 +3963,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">トークン</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -3943,5 +3943,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -3939,5 +3939,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -914,14 +914,6 @@
         <source>Password</source>
         <translation>비밀번호</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>송금 받기</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>송금하기</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>환율</translation>
@@ -2210,10 +2202,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>활성화된 오퍼가 현재 없습니다.
 잠시 후 재시도하거나 오퍼를 만드십시오.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>보내기</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3576,10 +3564,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>업데이트 중</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>받기</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Rate</translation>
@@ -3945,6 +3929,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp 파일의 압축을 풀 수 없습니다.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -3956,7 +3956,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3985,6 +3986,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -4064,5 +4064,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ko_KR.ts
+++ b/ui/i18n/ko_KR.ts
@@ -2054,7 +2054,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -3948,5 +3948,49 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -4069,5 +4069,9 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -3961,7 +3961,8 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3990,6 +3991,82 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -2058,8 +2058,9 @@ Uw versie is: %2. Controleer op updates.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum node</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Ontvang bedrag</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Verzend bedrag</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Wisselkoers</translation>
@@ -2213,10 +2205,6 @@ Controleer de %1 blockchain. Lage fees kunnen het voltooien een transactie ernst
 Please try again later or create an offer yourself.</source>
         <translation>Er zijn momenteel geen actieve aanbiedingen.
 Probeer het later opnieuw of maak zelf een aanbieding.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Verzend</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3581,10 +3569,6 @@ Herstart de wallet en probeer het opnieuw.</translation>
         <source>updating</source>
         <translation>bijwerken</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Ontvang</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Rate</translation>
@@ -3950,6 +3934,14 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Kan de DApp-bestanden niet uitpakken.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/nl_NL.ts
+++ b/ui/i18n/nl_NL.ts
@@ -3944,5 +3944,9 @@ Verbind uw Hardware Wallet om de transactie af te ronden.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -3946,5 +3946,9 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -2059,8 +2059,9 @@ Sua versão é: %2. Por favor, verifique se há atualizações.</translation>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Nó Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Nó Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -4071,5 +4071,9 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -3963,7 +3963,8 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3992,6 +3993,82 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -916,14 +916,6 @@
         <source>Password</source>
         <translation>Senha</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Receber valor</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Enviar valor</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Taxa de Câmbio</translation>
@@ -2214,10 +2206,6 @@ Verifique a blockchain %1 por su própria conta. Taxas baixas podem levar muito 
 Please try again later or create an offer yourself.</source>
         <translation>Não há ofertas ativas no momento.
 Por favor, tente novamente mais tarde ou crie uma oferta.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Mandar</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3583,10 +3571,6 @@ Por favor, reinicie a carteira e tente novamente.</translation>
         <source>updating</source>
         <translation>atualizando</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Receber</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Taxa</translation>
@@ -3952,6 +3936,14 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Não foi possível extrair os arquivos da DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/pt_BR.ts
+++ b/ui/i18n/pt_BR.ts
@@ -3950,5 +3950,49 @@ Conecte a sua Carteira Física para finalizar a transação.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -2067,8 +2067,9 @@ Your version is: %2. Please, check for updates.</source>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Узел Ethereum</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Узел Ethereum</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -3960,5 +3960,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -4085,5 +4085,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -3977,7 +3977,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4006,6 +4007,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Токен</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -918,14 +918,6 @@
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Сумма к получению</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Отправляемая сумма</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Обменный курс</translation>
@@ -2223,10 +2215,6 @@ much longer for a transaction to complete.</source>
 Please try again later or create an offer yourself.</source>
         <translation>В данный момент нет активных предложений.
 Пожалуйста, повторите попытку позже или создайте предложение самостоятельно.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Отправить</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3597,10 +3585,6 @@ Please, restart the wallet and try again.</source>
         <source>updating</source>
         <translation>обновление</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Получить</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Курс</translation>
@@ -3966,6 +3950,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не удалось распаковать файлы DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/ru_RU.ts
+++ b/ui/i18n/ru_RU.ts
@@ -3964,5 +3964,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -3971,5 +3971,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -4096,5 +4096,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -3975,5 +3975,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -3988,7 +3988,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4017,6 +4018,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -924,14 +924,6 @@
         <source>Password</source>
         <translation type="unfinished">Password</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Износ који примате</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Износ који шаљете</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Стопа Мењачнице</translation>
@@ -2230,10 +2222,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Тренутно нема активних понуда.
 Молим проверите поново касније или сами креирајте понуду.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation type="unfinished">Send</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3601,10 +3589,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>ажурирање</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation type="unfinished">Receive</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Курс</translation>
@@ -3977,6 +3961,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Nije moguće raspakovati DApp datoteke.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sr_SR.ts
+++ b/ui/i18n/sr_SR.ts
@@ -2073,7 +2073,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -3945,5 +3945,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -915,14 +915,6 @@
         <source>Password</source>
         <translation>Lösenord</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Ta emot belopp</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Skicka belopp</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Växelkurs</translation>
@@ -2212,10 +2204,6 @@ mycket längre tid för en transaktion att slutföras.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>Det finns inga aktiva erbjudanden för tillfället. 
 Vänligen testa igen senare eller skapa ett erbjudande själv.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Skicka</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3582,10 +3570,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>uppdaterar</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Ta emot</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Kurs</translation>
@@ -3951,6 +3935,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Det gick inte att extrahera DApp-filerna.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -4070,5 +4070,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -3962,7 +3962,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3991,6 +3992,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -2056,7 +2056,8 @@ Din version är: %2. Sök efter uppdateringar.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/sv_SE.ts
+++ b/ui/i18n/sv_SE.ts
@@ -3949,5 +3949,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -2055,7 +2055,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -3943,5 +3943,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -3939,5 +3939,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -914,14 +914,6 @@
         <source>Password</source>
         <translation>รหัสผ่าน</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>จำนวนที่ได้รับ</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>จำนวนที่โอน</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>อัตราแลกเปลี่ยน</translation>
@@ -2211,10 +2203,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation>ไม่มีข้อเสนอการแลกเปลี่ยนใดๆในตอนนี้
 กรุณาลองอีกครั้งหรือสร้างข้อเสนอของตัวเองเลย</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>โอน</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3576,10 +3564,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>กำลังอัพเดท</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>รับ</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>เรท</translation>
@@ -3945,6 +3929,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>ไม่สามารถแตกไฟล์ DApp ได้</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -4064,5 +4064,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/th_TH.ts
+++ b/ui/i18n/th_TH.ts
@@ -3956,7 +3956,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3985,6 +3986,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">โทเค็น</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -3943,5 +3943,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -3939,5 +3939,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -914,14 +914,6 @@
         <source>Password</source>
         <translation>Şifre</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation type="unfinished">Receive amount</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation type="unfinished">Send amount</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation type="unfinished">Exchange rate</translation>
@@ -2210,10 +2202,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation type="unfinished">There are no active offers at the moment.
 Please try again later or create an offer yourself.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Gönder</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3576,10 +3564,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>güncelleniyor</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Al</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation type="unfinished">Rate</translation>
@@ -3945,6 +3929,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>DApp dosyaları çıkarılamadı.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -3956,7 +3956,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3985,6 +3986,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -4064,5 +4064,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/tr_TR.ts
+++ b/ui/i18n/tr_TR.ts
@@ -2054,7 +2054,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -3959,5 +3959,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -2064,8 +2064,9 @@ Your version is: %2. Please, check for updates.</source>
         <translation>Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>Ethereum вузол</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">Ethereum вузол</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -3955,5 +3955,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -3972,7 +3972,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4001,6 +4002,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Токен</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -4080,5 +4080,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/uk_UA.ts
+++ b/ui/i18n/uk_UA.ts
@@ -918,14 +918,6 @@
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Отримати суму</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>Відправити суму</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>Обмінний курс</translation>
@@ -2220,10 +2212,6 @@ much longer for a transaction to complete.</source>
 Please try again later or create an offer yourself.</source>
         <translation>На цей час немає активних пропозицій.
 Спробуйте пізніше або створіть пропозицію самостійно.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Надіслати</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3592,10 +3580,6 @@ Please, restart the wallet and try again.</source>
         <source>updating</source>
         <translation>оновлення</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Отримати</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Оцінити</translation>
@@ -3961,6 +3945,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Не вдалося розпакувати файли DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -2062,7 +2062,8 @@ Your version is: %2. Please, check for updates.</translation>
         <translation type="unfinished">Ethereum</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
         <translation type="unfinished">Ethereum node</translation>
     </message>
     <message id="ethereum-show-seed-title">

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -920,14 +920,6 @@
         <source>Password</source>
         <translation>Mật khẩu</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>Nhận số tiền</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation type="unfinished">Send amount</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation type="unfinished">Exchange rate</translation>
@@ -2219,10 +2211,6 @@ much longer for a transaction to complete.</translation>
 Please try again later or create an offer yourself.</source>
         <translation type="unfinished">There are no active offers at the moment.
 Please try again later or create an offer yourself.</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>Gửi</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3582,10 +3570,6 @@ Please, restart the wallet and try again.</translation>
         <source>updating</source>
         <translation>đang cập nhật</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>Nhận</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>Đánh giá</translation>
@@ -3958,6 +3942,14 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>Không thể giải nén các tệp DApp.</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -3952,5 +3952,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -3956,5 +3956,49 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -3969,7 +3969,8 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -3998,6 +3999,82 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">Token</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/vi_VI.ts
+++ b/ui/i18n/vi_VI.ts
@@ -4077,5 +4077,9 @@ Connect your Hardware Wallet to finalize the transaction.</translation>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -3959,5 +3959,49 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings-eth-infura">
+        <source>Infura</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-custom-rpc">
+        <source>Custom RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-endpoint">
+        <source>Ethereum RPC endpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-rpc-note">
+        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-check-connection">
+        <source>Check connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-failed">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-mainnet">
+        <source>Ethereum Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-sepolia">
+        <source>Sepolia Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-chain-other">
+        <source>chain %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-ok">
+        <source>Connected to %1. Latest block: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-eth-endpoint-wrong-network">
+        <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -922,14 +922,6 @@
         <source>Password</source>
         <translation>密码</translation>
     </message>
-    <message id="receive-amount-swap-label">
-        <source>Receive amount</source>
-        <translation>收款金额</translation>
-    </message>
-    <message id="sent-amount-label">
-        <source>Send amount</source>
-        <translation>发送金额</translation>
-    </message>
     <message id="general-rate">
         <source>Exchange rate</source>
         <translation>汇率</translation>
@@ -2226,10 +2218,6 @@ much longer for a transaction to complete.</source>
 Please try again later or create an offer yourself.</source>
         <translation>目前没有活动的报价。
 请稍后再试或自己创建报价。</translation>
-    </message>
-    <message id="atomic-swap-amount-send">
-        <source>Send</source>
-        <translation>付款</translation>
     </message>
     <message id="atomic-swap-all-transactions-tab">
         <source>All</source>
@@ -3592,10 +3580,6 @@ Please, restart the wallet and try again.</source>
         <source>updating</source>
         <translation>正在更新</translation>
     </message>
-    <message id="general-receive">
-        <source>Receive</source>
-        <translation>收款</translation>
-    </message>
     <message id="swap-rate">
         <source>Rate</source>
         <translation>评价</translation>
@@ -3961,6 +3945,14 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     <message id="dapp-install-err-extract">
         <source>Couldn&apos;t extract the DApp files.</source>
         <translation>无法解压 DApp 文件。</translation>
+    </message>
+    <message id="atomic-swap-i-send">
+        <source>I send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="atomic-swap-i-receive">
+        <source>I receive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -2070,8 +2070,9 @@ Your version is: %2. Please, check for updates.</source>
         <translation>以太坊</translation>
     </message>
     <message id="settings-swap-ethereum-node">
-        <source>Ethereum node</source>
-        <translation>以太坊节点</translation>
+        <source>Ethereum</source>
+        <oldsource>Ethereum node</oldsource>
+        <translation type="unfinished">以太坊节点</translation>
     </message>
     <message id="ethereum-show-seed-title">
         <source>Ethereum seed phrase</source>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -3955,5 +3955,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>I receive</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-details-unlock-note">
+        <source>While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -4080,5 +4080,9 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="swap-not-enough-eth-redeem">
+        <source>Not enough ETH to pay the redeem transaction fee (%1 needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/ui/i18n/zh_CN.ts
+++ b/ui/i18n/zh_CN.ts
@@ -3972,7 +3972,8 @@ Connect your Hardware Wallet to finalize the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-rpc-note">
-        <source>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</source>
+        <source>Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node.</source>
+        <oldsource>Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings-eth-check-connection">
@@ -4001,6 +4002,82 @@ Connect your Hardware Wallet to finalize the transaction.</source>
     </message>
     <message id="settings-eth-endpoint-wrong-network">
         <source>Connected to %1, but Ethereum Mainnet is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-section-title">
+        <source>Custom ERC-20 tokens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-remove">
+        <source>remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-address-placeholder">
+        <source>0x contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-lookup">
+        <source>Look up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add">
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-info">
+        <source>%1, %2 decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-title">
+        <source>Token</source>
+        <translation type="unfinished">令牌</translation>
+    </message>
+    <message id="swap-accept-token-contract-label">
+        <source>Contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-symbol-label">
+        <source>Symbol / decimals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning">
+        <source>Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-title">
+        <source>Confidential Asset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-id-unit">
+        <source>Asset id %1, unit %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-asset-beam-fee">
+        <source>You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="swap-accept-token-warning-confirm">
+        <source>%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-invalid-address">
+        <source>Invalid contract address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-builtin">
+        <source>built-in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-open">
+        <source>+ Add token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-add-cancel">
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings-swap-token-already-added">
+        <source>This token is already supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/model/app_model.cpp
+++ b/ui/model/app_model.cpp
@@ -557,6 +557,9 @@ void AppModel::startWallet()
         swapTransactionCreator->RegisterFactory(AtomicSwapCoin::Dai, secondSideFactory);
         swapTransactionCreator->RegisterFactory(AtomicSwapCoin::Usdt, secondSideFactory);
         swapTransactionCreator->RegisterFactory(AtomicSwapCoin::WBTC, secondSideFactory);
+        // per-offer custom ERC-20 tokens: EthereumSide resolves the contract and
+        // decimals from the tx params (AtomicSwapTokenContract/Decimals)
+        swapTransactionCreator->RegisterFactory(AtomicSwapCoin::Erc20Token, secondSideFactory);
     }
 
     additionalTxCreators->emplace(TxType::AtomicSwap, swapTransactionCreator);

--- a/ui/model/settings.cpp
+++ b/ui/model/settings.cpp
@@ -44,6 +44,7 @@ namespace
     const char* kIsAlowedBeamMWLink = "beam_mw_links_allowed";
     const char* kRateUnit = "rateUnit";
     const char* kLastAssetSelection = "lastAssetSelection";
+    const char* kEthCustomTokens = "eth/customTokens";
     const char* kHideSeedValidationPromo = "hideSeedValidationPromo";
     const char* kDevMode ="dev_mode";
 
@@ -1177,6 +1178,43 @@ void WalletSettings::setLastAssetSelection(QVector<beam::Asset::ID> selection)
     out << selection;
 
     m_accountSettings.m_data.setValue(kLastAssetSelection, QVariant::fromValue<QByteArray>(ser));
+}
+
+QList<QMap<QString, QVariant>> WalletSettings::getEthCustomTokens() const
+{
+    Lock lock(m_mutex);
+
+    auto ser = m_accountSettings.m_data.value(kEthCustomTokens).value<QByteArray>();
+    QDataStream in(&ser, QIODevice::ReadOnly);
+    QVariantList res;
+    in >> res;
+
+    QList<QMap<QString, QVariant>> result;
+    for (const auto& entry : res)
+    {
+        result.push_back(entry.toMap());
+    }
+    return result;
+}
+
+void WalletSettings::setEthCustomTokens(const QList<QMap<QString, QVariant>>& tokens)
+{
+    {
+        Lock lock(m_mutex);
+
+        QVariantList toStore;
+        for (const auto& token : tokens)
+        {
+            toStore.push_back(token);
+        }
+
+        QByteArray ser;
+        QDataStream out(&ser, QIODevice::WriteOnly);
+        out << toStore;
+
+        m_accountSettings.m_data.setValue(kEthCustomTokens, QVariant::fromValue<QByteArray>(ser));
+    }
+    emit ethCustomTokensChanged();
 }
 
 bool WalletSettings::getShowInProgress() const

--- a/ui/model/settings.h
+++ b/ui/model/settings.h
@@ -17,6 +17,8 @@
 #include <QSettings>
 #include <QDir>
 #include <QStringList>
+#include <QMap>
+#include <QVariant>
 #include <chrono>
 #include <mutex>
 #include "model/wallet_model.h"
@@ -134,6 +136,11 @@ public:
     void removeAllowedAsset(beam::Asset::ID asset);
 #endif  // BEAM_ASSET_SWAP_SUPPORT
 
+    // per-wallet custom ERC-20 tokens added for atomic-swap offers
+    // (beam::ethereum::Settings has no free-form storage for this)
+    QList<QMap<QString, QVariant>> getEthCustomTokens() const;
+    void setEthCustomTokens(const QList<QMap<QString, QVariant>>& tokens);
+
     uint8_t getMaxPrivacyAnonymitySet() const;
     void setMaxPrivacyAnonymitySet(uint8_t anonymitySet);
 
@@ -207,6 +214,7 @@ signals:
     void secondCurrencyChanged();
     void IPFSSettingsChanged();
     void generalMouseEvent();
+    void ethCustomTokensChanged();
 
 private:
     struct AccountSettings

--- a/ui/model/swap_eth_client_model.cpp
+++ b/ui/model/swap_eth_client_model.cpp
@@ -26,6 +26,18 @@ namespace
 {
     const int kBalanceUpdateInterval = 10 * 1000; // 10 seconds
     const int kFeeRateUpdateInterval = 60 * 1000; // 1 minute
+
+    // forwards ITokenInfoAsync calls onto the eth reactor thread, mirroring
+    // Client's own EthereumClientBridge (client.cpp)
+    struct TokenInfoAsyncBridge : public Bridge<ITokenInfoAsync>
+    {
+        BRIDGE_INIT(TokenInfoAsyncBridge);
+
+        void RequestTokenInfo(std::string contractAddress) override
+        {
+            call_async(&ITokenInfoAsync::RequestTokenInfo, std::move(contractAddress));
+        }
+    };
 }
 
 SwapEthClientModel::SwapEthClientModel(beam::ethereum::IBridgeHolder::Ptr bridgeHolder,
@@ -34,6 +46,9 @@ SwapEthClientModel::SwapEthClientModel(beam::ethereum::IBridgeHolder::Ptr bridge
     : ethereum::Client(bridgeHolder, std::move(settingsProvider), reactor)
     , m_balanceTimer(this)
     , m_feeRateTimer(this)
+    , m_tokenInfoBridgeHolder(bridgeHolder)
+    , m_tokenInfoReactor(reactor)
+    , m_tokenInfoAsync(std::make_shared<TokenInfoAsyncBridge>(*static_cast<ITokenInfoAsync*>(this), reactor))
 {
     qRegisterMetaType<beam::ethereum::Client::Status>("beam::ethereum::Client::Status");
     qRegisterMetaType<beam::ethereum::IBridge::ErrorType>("beam::ethereum::IBridge::ErrorType");
@@ -49,6 +64,7 @@ SwapEthClientModel::SwapEthClientModel(beam::ethereum::IBridgeHolder::Ptr bridge
     connect(this, SIGNAL(gotStatus(beam::ethereum::Client::Status)), this, SLOT(setStatus(beam::ethereum::Client::Status)));
     connect(this, SIGNAL(gotCanModifySettings(bool)), this, SLOT(setCanModifySettings(bool)));
     connect(this, SIGNAL(gotConnectionError(beam::ethereum::IBridge::ErrorType)), this, SLOT(setConnectionError(beam::ethereum::IBridge::ErrorType)));
+    connect(this, &SwapEthClientModel::gotTokenBalance, this, &SwapEthClientModel::setTokenBalance);
 
     requestBalance();
     requestEstimatedFeeRate();
@@ -127,7 +143,10 @@ void SwapEthClientModel::OnConnectionError(beam::ethereum::IBridge::ErrorType er
 
 void SwapEthClientModel::OnEndpointValidated(uint64_t chainID, uint64_t blockNumber, const beam::ethereum::IBridge::Error& error)
 {
-    emit endpointValidated(chainID, blockNumber, error.m_type == beam::ethereum::IBridge::None);
+    emit endpointValidated(chainID, blockNumber,
+                           error.m_type == beam::ethereum::IBridge::None,
+                           error.m_type == beam::ethereum::IBridge::InvalidNetwork,
+                           QString::fromStdString(error.m_message));
 }
 
 void SwapEthClientModel::requestBalance()
@@ -140,6 +159,17 @@ void SwapEthClientModel::requestBalance()
         for (auto token : beam::wallet::kEthTokens)
         {
             GetAsync()->GetBalance(token);
+        }
+
+        // same cadence, for user-stored custom ERC-20 tokens
+        for (const auto& token : AppModel::getInstance().getSettings().getEthCustomTokens())
+        {
+            const auto contract = token.value("contract").toString().toStdString();
+            const auto decimals = static_cast<uint8_t>(token.value("decimals").toUInt());
+            if (!contract.empty())
+            {
+                GetAsync()->GetTokenBalance(contract, decimals);
+            }
         }
     }
 }
@@ -196,11 +226,71 @@ void SwapEthClientModel::setCanModifySettings(bool canModify)
     }
 }
 
+void SwapEthClientModel::requestTokenInfo(const std::string& contractAddress)
+{
+    m_tokenInfoAsync->RequestTokenInfo(contractAddress);
+}
+
+void SwapEthClientModel::RequestTokenInfo(std::string contractAddress)
+{
+    // runs on the eth reactor thread
+    auto bridge = m_tokenInfoBridgeHolder->Get(m_tokenInfoReactor, *this);
+    if (!bridge)
+    {
+        //% "Cannot connect to node. Please check your network connection."
+        emit gotTokenInfo(QString::fromStdString(contractAddress), QString(), 0, qtTrId("swap-connection-error"));
+        return;
+    }
+
+    auto weak = weak_from_this();
+    bridge->getTokenInfo(contractAddress,
+        [this, weak, contractAddress](const ethereum::IBridge::Error& error, const std::string& symbol, uint8_t decimals)
+    {
+        auto sp = weak.lock(); // keeps *this alive across the emit below
+        if (!sp)
+        {
+            return;
+        }
+
+        emit gotTokenInfo(QString::fromStdString(contractAddress),
+                           QString::fromStdString(symbol),
+                           decimals,
+                           error.m_type == ethereum::IBridge::None ? QString() : QString::fromStdString(error.m_message));
+    });
+}
+
 void SwapEthClientModel::setConnectionError(beam::ethereum::IBridge::ErrorType error)
 {
     if (m_connectionError != error)
     {
         m_connectionError = error;
         emit connectionErrorChanged();
+    }
+}
+
+void SwapEthClientModel::OnTokenBalance(const std::string& tokenContract, beam::Amount balance)
+{
+    emit gotTokenBalance(QString::fromStdString(tokenContract), balance);
+}
+
+beam::Amount SwapEthClientModel::getTokenBalance(const QString& contract) const
+{
+    auto it = m_tokenBalances.find(contract.toLower());
+    return it != m_tokenBalances.end() ? it->second : 0;
+}
+
+void SwapEthClientModel::setTokenBalance(const QString& contract, beam::Amount balance)
+{
+    auto key = contract.toLower();
+    auto it = m_tokenBalances.find(key);
+    if (it == m_tokenBalances.end())
+    {
+        m_tokenBalances.emplace(key, balance);
+        emit tokenBalancesChanged();
+    }
+    else if (it->second != balance)
+    {
+        it->second = balance;
+        emit tokenBalancesChanged();
     }
 }

--- a/ui/model/swap_eth_client_model.cpp
+++ b/ui/model/swap_eth_client_model.cpp
@@ -26,18 +26,6 @@ namespace
 {
     const int kBalanceUpdateInterval = 10 * 1000; // 10 seconds
     const int kFeeRateUpdateInterval = 60 * 1000; // 1 minute
-
-    // forwards ITokenInfoAsync calls onto the eth reactor thread, mirroring
-    // Client's own EthereumClientBridge (client.cpp)
-    struct TokenInfoAsyncBridge : public Bridge<ITokenInfoAsync>
-    {
-        BRIDGE_INIT(TokenInfoAsyncBridge);
-
-        void RequestTokenInfo(std::string contractAddress) override
-        {
-            call_async(&ITokenInfoAsync::RequestTokenInfo, std::move(contractAddress));
-        }
-    };
 }
 
 SwapEthClientModel::SwapEthClientModel(beam::ethereum::IBridgeHolder::Ptr bridgeHolder,
@@ -46,9 +34,6 @@ SwapEthClientModel::SwapEthClientModel(beam::ethereum::IBridgeHolder::Ptr bridge
     : ethereum::Client(bridgeHolder, std::move(settingsProvider), reactor)
     , m_balanceTimer(this)
     , m_feeRateTimer(this)
-    , m_tokenInfoBridgeHolder(bridgeHolder)
-    , m_tokenInfoReactor(reactor)
-    , m_tokenInfoAsync(std::make_shared<TokenInfoAsyncBridge>(*static_cast<ITokenInfoAsync*>(this), reactor))
 {
     qRegisterMetaType<beam::ethereum::Client::Status>("beam::ethereum::Client::Status");
     qRegisterMetaType<beam::ethereum::IBridge::ErrorType>("beam::ethereum::IBridge::ErrorType");
@@ -228,35 +213,24 @@ void SwapEthClientModel::setCanModifySettings(bool canModify)
 
 void SwapEthClientModel::requestTokenInfo(const std::string& contractAddress)
 {
-    m_tokenInfoAsync->RequestTokenInfo(contractAddress);
+    GetAsync()->GetTokenInfo(contractAddress);
 }
 
-void SwapEthClientModel::RequestTokenInfo(std::string contractAddress)
+void SwapEthClientModel::OnTokenInfo(const std::string& tokenContract, const std::string& symbol, uint8_t decimals, const beam::ethereum::IBridge::Error& error)
 {
-    // runs on the eth reactor thread
-    auto bridge = m_tokenInfoBridgeHolder->Get(m_tokenInfoReactor, *this);
-    if (!bridge)
+    QString errorStr;
+    if (error.m_type != beam::ethereum::IBridge::None)
     {
-        //% "Cannot connect to node. Please check your network connection."
-        emit gotTokenInfo(QString::fromStdString(contractAddress), QString(), 0, qtTrId("swap-connection-error"));
-        return;
+        errorStr = error.m_message.empty()
+            //% "Cannot connect to node. Please check your network connection."
+            ? qtTrId("swap-connection-error")
+            : QString::fromStdString(error.m_message);
     }
 
-    auto weak = weak_from_this();
-    bridge->getTokenInfo(contractAddress,
-        [this, weak, contractAddress](const ethereum::IBridge::Error& error, const std::string& symbol, uint8_t decimals)
-    {
-        auto sp = weak.lock(); // keeps *this alive across the emit below
-        if (!sp)
-        {
-            return;
-        }
-
-        emit gotTokenInfo(QString::fromStdString(contractAddress),
-                           QString::fromStdString(symbol),
-                           decimals,
-                           error.m_type == ethereum::IBridge::None ? QString() : QString::fromStdString(error.m_message));
-    });
+    emit gotTokenInfo(QString::fromStdString(tokenContract),
+                      QString::fromStdString(symbol),
+                      decimals,
+                      errorStr);
 }
 
 void SwapEthClientModel::setConnectionError(beam::ethereum::IBridge::ErrorType error)

--- a/ui/model/swap_eth_client_model.cpp
+++ b/ui/model/swap_eth_client_model.cpp
@@ -94,6 +94,11 @@ beam::ethereum::IBridge::ErrorType SwapEthClientModel::getConnectionError() cons
     return m_connectionError;
 }
 
+void SwapEthClientModel::validateEndpoint()
+{
+    GetAsync()->ValidateEndpoint();
+}
+
 void SwapEthClientModel::OnBalance(wallet::AtomicSwapCoin swapCoin, Amount balance)
 {
     emit gotBalance(swapCoin, balance);
@@ -118,6 +123,11 @@ void SwapEthClientModel::OnChangedSettings()
 void SwapEthClientModel::OnConnectionError(beam::ethereum::IBridge::ErrorType error)
 {
     emit gotConnectionError(error);
+}
+
+void SwapEthClientModel::OnEndpointValidated(uint64_t chainID, uint64_t blockNumber, const beam::ethereum::IBridge::Error& error)
+{
+    emit endpointValidated(chainID, blockNumber, error.m_type == beam::ethereum::IBridge::None);
 }
 
 void SwapEthClientModel::requestBalance()

--- a/ui/model/swap_eth_client_model.h
+++ b/ui/model/swap_eth_client_model.h
@@ -17,10 +17,21 @@
 #include <QObject>
 #include <QTimer>
 #include "wallet/transactions/swaps/bridges/ethereum/client.h"
+#include "utility/bridge.h"
+
+// outbound-only async interface used to marshal SwapEthClientModel::requestTokenInfo()
+// onto the eth reactor thread, the same way Client's own IClientAsync does
+class ITokenInfoAsync
+{
+public:
+    virtual ~ITokenInfoAsync() = default;
+    virtual void RequestTokenInfo(std::string contractAddress) = 0;
+};
 
 class SwapEthClientModel
     : public QObject
     , public beam::ethereum::Client
+    , private ITokenInfoAsync
 {
     Q_OBJECT
 public:
@@ -37,19 +48,34 @@ public:
     beam::ethereum::IBridge::ErrorType getConnectionError() const;
     void validateEndpoint();
 
+    // Looks up symbol()/decimals() of an arbitrary ERC-20 contract (per-offer
+    // custom tokens have no static settings entry, unlike kEthTokens). Client's
+    // IClientAsync has no such call, so this hops onto the eth reactor thread
+    // itself via the same Bridge<> utility Client uses internally, and reports
+    // back through gotTokenInfo (Qt auto-queues it to the UI thread like the
+    // other gotXXX signals below).
+    void requestTokenInfo(const std::string& contractAddress);
+
+    // wallet-units balance (already normalized to min(decimals,9) by Client::GetTokenBalance)
+    // of a stored custom ERC-20 token, or 0 if not fetched yet
+    beam::Amount getTokenBalance(const QString& contract) const;
+
 signals:
     void gotStatus(beam::ethereum::Client::Status status);
     void gotBalance(beam::wallet::AtomicSwapCoin swapCoin, beam::Amount balance);
     void gotEstimatedGasPrice(beam::Amount estimatedFeeRate);
     void gotCanModifySettings(bool canModify);
     void gotConnectionError(const beam::ethereum::IBridge::ErrorType& error);
+    void gotTokenInfo(const QString& contract, const QString& symbol, uint decimals, const QString& error);
+    void gotTokenBalance(const QString& contract, beam::Amount balance);
 
     void canModifySettingsChanged();
     void balanceChanged();
+    void tokenBalancesChanged();
     void estimatedFeeRateChanged();
     void statusChanged();
     void connectionErrorChanged();
-    void endpointValidated(quint64 chainID, quint64 blockNumber, bool ok);
+    void endpointValidated(quint64 chainID, quint64 blockNumber, bool ok, bool wrongNetwork, const QString& errorMsg);
 
 private:
     void OnStatus(Status status) override;
@@ -59,6 +85,10 @@ private:
     void OnChangedSettings() override;
     void OnConnectionError(beam::ethereum::IBridge::ErrorType error) override;
     void OnEndpointValidated(uint64_t chainID, uint64_t blockNumber, const beam::ethereum::IBridge::Error& error) override;
+    void OnTokenBalance(const std::string& tokenContract, beam::Amount balance) override;
+
+    // ITokenInfoAsync, runs on the eth reactor thread
+    void RequestTokenInfo(std::string contractAddress) override;
 
 private slots:
     void requestBalance();
@@ -68,13 +98,21 @@ private slots:
     void setStatus(beam::ethereum::Client::Status status);
     void setCanModifySettings(bool canModify);
     void setConnectionError(beam::ethereum::IBridge::ErrorType error);
+    void setTokenBalance(const QString& contract, beam::Amount balance);
 
 private:
     QTimer m_balanceTimer;
     QTimer m_feeRateTimer;
     std::map<beam::wallet::AtomicSwapCoin, beam::Amount> m_balances;
+    std::map<QString, beam::Amount> m_tokenBalances; // key: lowercased contract address
     beam::Amount m_gasPrice = 0;
     Status m_status = Status::Unknown;
     bool m_canModifySettings = true;
     beam::ethereum::IBridge::ErrorType m_connectionError = beam::ethereum::IBridge::ErrorType::None;
+
+    // duplicated from Client (whose own copies are private) so getTokenInfo,
+    // which Client/IClientAsync don't expose, can reach the same shared bridge
+    beam::ethereum::IBridgeHolder::Ptr m_tokenInfoBridgeHolder;
+    beam::io::Reactor& m_tokenInfoReactor;
+    std::shared_ptr<ITokenInfoAsync> m_tokenInfoAsync;
 };

--- a/ui/model/swap_eth_client_model.h
+++ b/ui/model/swap_eth_client_model.h
@@ -17,21 +17,10 @@
 #include <QObject>
 #include <QTimer>
 #include "wallet/transactions/swaps/bridges/ethereum/client.h"
-#include "utility/bridge.h"
-
-// outbound-only async interface used to marshal SwapEthClientModel::requestTokenInfo()
-// onto the eth reactor thread, the same way Client's own IClientAsync does
-class ITokenInfoAsync
-{
-public:
-    virtual ~ITokenInfoAsync() = default;
-    virtual void RequestTokenInfo(std::string contractAddress) = 0;
-};
 
 class SwapEthClientModel
     : public QObject
     , public beam::ethereum::Client
-    , private ITokenInfoAsync
 {
     Q_OBJECT
 public:
@@ -48,12 +37,9 @@ public:
     beam::ethereum::IBridge::ErrorType getConnectionError() const;
     void validateEndpoint();
 
-    // Looks up symbol()/decimals() of an arbitrary ERC-20 contract (per-offer
-    // custom tokens have no static settings entry, unlike kEthTokens). Client's
-    // IClientAsync has no such call, so this hops onto the eth reactor thread
-    // itself via the same Bridge<> utility Client uses internally, and reports
-    // back through gotTokenInfo (Qt auto-queues it to the UI thread like the
-    // other gotXXX signals below).
+    // symbol()/decimals() of an arbitrary ERC-20 contract (per-offer custom
+    // tokens have no static settings entry, unlike kEthTokens); reports back
+    // through gotTokenInfo
     void requestTokenInfo(const std::string& contractAddress);
 
     // wallet-units balance (already normalized to min(decimals,9) by Client::GetTokenBalance)
@@ -86,9 +72,7 @@ private:
     void OnConnectionError(beam::ethereum::IBridge::ErrorType error) override;
     void OnEndpointValidated(uint64_t chainID, uint64_t blockNumber, const beam::ethereum::IBridge::Error& error) override;
     void OnTokenBalance(const std::string& tokenContract, beam::Amount balance) override;
-
-    // ITokenInfoAsync, runs on the eth reactor thread
-    void RequestTokenInfo(std::string contractAddress) override;
+    void OnTokenInfo(const std::string& tokenContract, const std::string& symbol, uint8_t decimals, const beam::ethereum::IBridge::Error& error) override;
 
 private slots:
     void requestBalance();
@@ -110,9 +94,4 @@ private:
     bool m_canModifySettings = true;
     beam::ethereum::IBridge::ErrorType m_connectionError = beam::ethereum::IBridge::ErrorType::None;
 
-    // duplicated from Client (whose own copies are private) so getTokenInfo,
-    // which Client/IClientAsync don't expose, can reach the same shared bridge
-    beam::ethereum::IBridgeHolder::Ptr m_tokenInfoBridgeHolder;
-    beam::io::Reactor& m_tokenInfoReactor;
-    std::shared_ptr<ITokenInfoAsync> m_tokenInfoAsync;
 };

--- a/ui/model/swap_eth_client_model.h
+++ b/ui/model/swap_eth_client_model.h
@@ -35,6 +35,7 @@ public:
     beam::ethereum::Client::Status getStatus() const;
     bool canModifySettings() const;
     beam::ethereum::IBridge::ErrorType getConnectionError() const;
+    void validateEndpoint();
 
 signals:
     void gotStatus(beam::ethereum::Client::Status status);
@@ -48,6 +49,7 @@ signals:
     void estimatedFeeRateChanged();
     void statusChanged();
     void connectionErrorChanged();
+    void endpointValidated(quint64 chainID, quint64 blockNumber, bool ok);
 
 private:
     void OnStatus(Status status) override;
@@ -56,6 +58,7 @@ private:
     void OnCanModifySettingsChanged(bool canModify) override;
     void OnChangedSettings() override;
     void OnConnectionError(beam::ethereum::IBridge::ErrorType error) override;
+    void OnEndpointValidated(uint64_t chainID, uint64_t blockNumber, const beam::ethereum::IBridge::Error& error) override;
 
 private slots:
     void requestBalance();

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -227,7 +227,7 @@ ColumnLayout {
                         connectionError:          modelData.connectionError
                         getAddressesElectrum:     modelData.getAddressesElectrum
                         folded:                   creating ? modelData.folded :
-                                                             (unfoldSection == modelData.coinID ? false : (unfoldSection == "ALL_COINS" ? modelData.isConnected : true))
+                                                             (unfoldSection == modelData.coinID ? false : true)
 
 
                         mainSettingsViewModel:    viewModel
@@ -387,7 +387,7 @@ ColumnLayout {
                     mainSettingsViewModel:    viewModel
                     showStatus:               true
                     getEthereumAddresses:     viewModel.ethSettings.getEthereumAddresses
-                    folded:                   creating ? (unfoldSection == viewModel.ethSettings.coinID ? false : (unfoldSection == "ALL_COINS" ? viewModel.ethSettings.isConnected : true)) : viewModel.ethSettings.folded
+                    folded:                   creating ? (unfoldSection == viewModel.ethSettings.coinID ? false : true) : viewModel.ethSettings.folded
                     canChangeConnection:      viewModel.ethSettings.canChangeConnection
                     isConnected:              viewModel.ethSettings.isConnected
                     connectionStatus:         viewModel.ethSettings.connectionStatus

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -396,8 +396,6 @@ ColumnLayout {
                     accountIndex:             viewModel.ethSettings.accountIndex
                     useCustomRpc:             viewModel.ethSettings.useCustomRpc
                     customRpcUrl:             viewModel.ethSettings.customRpcUrl
-                    endpointCheckResult:      viewModel.ethSettings.endpointCheckResult
-                    endpointCheckOk:          viewModel.ethSettings.endpointCheckOk
 
                     Connections {
                         target: viewModel.ethSettings
@@ -433,11 +431,6 @@ ColumnLayout {
 
                         function onCustomRpcUrlChanged () {
                             swapEthSettings.customRpcUrl = viewModel.ethSettings.customRpcUrl
-                        }
-
-                        function onEndpointCheckResultChanged () {
-                            swapEthSettings.endpointCheckResult = viewModel.ethSettings.endpointCheckResult
-                            swapEthSettings.endpointCheckOk     = viewModel.ethSettings.endpointCheckOk
                         }
 
                         function onSeedPhrasesChanged () {

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -393,6 +393,10 @@ ColumnLayout {
                     connectionError:          viewModel.ethSettings.connectionError
                     infuraProjectID:          viewModel.ethSettings.infuraProjectID
                     accountIndex:             viewModel.ethSettings.accountIndex
+                    useCustomRpc:             viewModel.ethSettings.useCustomRpc
+                    customRpcUrl:             viewModel.ethSettings.customRpcUrl
+                    endpointCheckResult:      viewModel.ethSettings.endpointCheckResult
+                    endpointCheckOk:          viewModel.ethSettings.endpointCheckOk
 
                     Connections {
                         target: viewModel.ethSettings
@@ -422,6 +426,19 @@ ColumnLayout {
                             swapEthSettings.accountIndex = viewModel.ethSettings.accountIndex
                         }
 
+                        function onUseCustomRpcChanged () {
+                            swapEthSettings.useCustomRpc = viewModel.ethSettings.useCustomRpc
+                        }
+
+                        function onCustomRpcUrlChanged () {
+                            swapEthSettings.customRpcUrl = viewModel.ethSettings.customRpcUrl
+                        }
+
+                        function onEndpointCheckResultChanged () {
+                            swapEthSettings.endpointCheckResult = viewModel.ethSettings.endpointCheckResult
+                            swapEthSettings.endpointCheckOk     = viewModel.ethSettings.endpointCheckOk
+                        }
+
                         function onSeedPhrasesChanged () {
                             swapEthSettings.seedPhrases = viewModel.ethSettings.seedPhrases
                         }
@@ -439,6 +456,7 @@ ColumnLayout {
                     onRestoreSeedPhrases:        viewModel.ethSettings.restoreSeedPhrases()
                     onCopySeedPhrases:           viewModel.ethSettings.copySeedPhrases()
                     onValidateCurrentSeedPhrase: viewModel.ethSettings.validateCurrentSeedPhrase()
+                    onValidateEndpoint:          viewModel.ethSettings.validateEndpoint()
 
                     Binding {
                         target:   viewModel.ethSettings
@@ -456,6 +474,18 @@ ColumnLayout {
                         target:   viewModel.ethSettings
                         property: "accountIndex"
                         value:    swapEthSettings.accountIndex
+                    }
+
+                    Binding {
+                        target:   viewModel.ethSettings
+                        property: "useCustomRpc"
+                        value:    swapEthSettings.useCustomRpc
+                    }
+
+                    Binding {
+                        target:   viewModel.ethSettings
+                        property: "customRpcUrl"
+                        value:    swapEthSettings.customRpcUrl
                     }
                 }
             }

--- a/ui/view/Settings.qml
+++ b/ui/view/Settings.qml
@@ -376,6 +376,7 @@ ColumnLayout {
 
                 SwapEthSettings {
                     id:                       swapEthSettings
+                    ethSettings:              viewModel.ethSettings
                     title:                    viewModel.ethSettings.title
                     generalTitle:             viewModel.ethSettings.generalTitle
                     showSeedDialogTitle:      viewModel.ethSettings.showSeedDialogTitle

--- a/ui/view/accept_asset_swap.qml
+++ b/ui/view/accept_asset_swap.qml
@@ -58,8 +58,8 @@ ColumnLayout {
                     // Send amount
                     //
                     Panel {
-                        //% "Send amount"
-                        title:                   qsTrId("sent-amount-label")
+                        //% "I send"
+                        title:                   qsTrId("atomic-swap-i-send")
                         Layout.fillWidth:        true
 
                         content:
@@ -108,8 +108,8 @@ ColumnLayout {
                     // Receive amount
                     //
                     Panel {
-                        //% "Receive amount"
-                        title:                   qsTrId("receive-amount-swap-label")
+                        //% "I receive"
+                        title:                   qsTrId("atomic-swap-i-receive")
                         Layout.fillWidth:        true
                         content:
 

--- a/ui/view/assets_swap.qml
+++ b/ui/view/assets_swap.qml
@@ -256,8 +256,8 @@ ColumnLayout {
         TableViewColumn {
             role: "send"
 
-            //% "Send"
-            title:     qsTrId("general-send")
+            //% "I send"
+            title:     qsTrId("atomic-swap-i-send")
             width:     150 * ordersTable.columnResizeRatio
             movable:   false
             resizable: false
@@ -283,8 +283,8 @@ ColumnLayout {
         TableViewColumn {
             role: "receive"
 
-            //% "Receive"
-            title: qsTrId("general-receive")
+            //% "I receive"
+            title: qsTrId("atomic-swap-i-receive")
             width:     150 * ordersTable.columnResizeRatio
             movable:   false
             resizable: false

--- a/ui/view/atomic_swap.qml
+++ b/ui/view/atomic_swap.qml
@@ -610,8 +610,8 @@ Please try again later or create an offer yourself."
 
                 TableViewColumn {
                     role: "amountSend"
-                    //% "Send"
-                    title: qsTrId("atomic-swap-amount-send")
+                    //% "I send"
+                    title: qsTrId("atomic-swap-i-send")
                     width: offersTable.columnWidth
                     movable: false
                     resizable: false
@@ -625,8 +625,8 @@ Please try again later or create an offer yourself."
 
                 TableViewColumn {
                     role: "amountReceive"
-                    //% "Receive"
-                    title: qsTrId("general-receive")
+                    //% "I receive"
+                    title: qsTrId("atomic-swap-i-receive")
                     width: offersTable.columnWidth
                     movable: false
                     resizable: false

--- a/ui/view/atomic_swap.qml
+++ b/ui/view/atomic_swap.qml
@@ -223,6 +223,30 @@ ColumnLayout {
             }
         }
 
+        // one card per stored custom ERC-20 token, live balance
+        // shown only while the eth client is connected - matches the DAI/USDT/WBTC rule
+        Repeater {
+            model: viewModel.customTokenCards
+
+            SwapCurrencyAmountPane {
+                gradLeft: modelData.color
+                amount:   modelData.available
+                unitName: modelData.symbol
+                isOk:     modelData.isConnected
+                swapSettingsPane: "ETH"
+                //% "Connecting..."
+                textConnecting: qsTrId("swap-connecting")
+                //% "Cannot connect to peer. Please check the address in Settings and try again."
+                textConnectionError: qsTrId("swap-beta-connection-error")
+                iconDelegate: Component {
+                    TokenIcon {
+                        tokenColor: modelData.color
+                        symbol:     modelData.symbol
+                    }
+                }
+            }
+        }
+
         Rectangle {
             id:                         swapOptions
             Layout.fillWidth:           true
@@ -413,22 +437,26 @@ ColumnLayout {
                     fontLetterSpacing: 0.47
                     color: Style.content_main
                     textRole: 'text'
-                    model: [
-                        {
-                            //% "(all)"
-                            text: qsTrId("atomic-swap-all-coins"),
-                            pair: ""
-                        },
-                        {text: "BTC",  pair: "^(btc-)|(-btc)$"}, // We need a separator '-' to distinguish 'btc' and 'wbtc' 
-                        {text: "DAI",  pair: "^(dai-)|(-dai)$"},
-                        {text: "DASH", pair: "^(dash-)|(-dash)$"},
-                        {text: "DOGE", pair: "^(doge-)|(-doge)$"},
-                        {text: "ETH",  pair: "^(eth-)|(-eth)$"},
-                        {text: "LTC",  pair: "^(ltc-)|(-ltc)$"},
-                        {text: "QTUM", pair: "^(qtum-)|(-qtum)$"},
-                        {text: "USDT", pair: "^(usdt-)|(-usdt)$"},
-                        {text: "WBTC", pair: "^(wbtc-)|(-wbtc)$"}
-                    ]
+                    // fixed classic coins + custom ERC-20 tokens + held CA's,
+                    // built on the C++ side (viewModel.coinFilterList) so the
+                    // combo stays in sync with settings/wallet changes
+                    model: viewModel.coinFilterList
+
+                    // regenerating the model resets currentIndex: restore the
+                    // selection by value (its filter pair), or fall back to "(all)"
+                    property string selectedPair: ""
+                    onActivated: selectedPair = model[currentIndex] ? model[currentIndex].pair : ""
+                    onModelChanged: {
+                        if (!model) return
+                        for (var i = 0; i < model.length; ++i) {
+                            if (model[i].pair === selectedPair) {
+                                if (currentIndex !== i) currentIndex = i
+                                return
+                            }
+                        }
+                        currentIndex = 0
+                        selectedPair = ""
+                    }
                 }
             }   // RowLayout
 
@@ -530,7 +558,7 @@ Please try again later or create an offer yourself."
                             ? viewModel.allOffersFitBalance
                             : viewModel.allOffers
                         filterRole: "pair"
-                        filterString: coinSelector.model[coinSelector.currentIndex].pair
+                        filterString: coinSelector.model[coinSelector.currentIndex] ? coinSelector.model[coinSelector.currentIndex].pair : ""
                         filterCaseSensitivity: Qt.CaseInsensitive
                     }
 

--- a/ui/view/atomic_swap.qml
+++ b/ui/view/atomic_swap.qml
@@ -881,6 +881,7 @@ Please try again later or create an offer yourself."
                             beamRedeemTxKernelId:           txRolesMap && txRolesMap.beamRedeemTxKernelId ? txRolesMap.beamRedeemTxKernelId : ""
                             beamRefundTxKernelId:           txRolesMap && txRolesMap.beamRefundTxKernelId ? txRolesMap.beamRefundTxKernelId : ""
                             stateDetails:                   txRolesMap && txRolesMap.stateDetails ? txRolesMap.stateDetails : ""
+                            coinsUnlockNote:                txRolesMap && txRolesMap.coinsUnlockNote ? txRolesMap.coinsUnlockNote : ""
                             failureReason:                  txRolesMap && txRolesMap.failureReason ? txRolesMap.failureReason : ""
                                     
                             onTextCopied: function (text) {

--- a/ui/view/controls/AmountInput.qml
+++ b/ui/view/controls/AmountInput.qml
@@ -97,8 +97,10 @@ ColumnLayout {
                 // Allow integers up to 12 digits (max safe for uint64 with 8 decimals).
                 // Exact overflow protection is handled by the C++ backend (decode_base10)
                 // and the isEnoughAmount / balance validation.
+                var decimals = currencies[currencyIdx].decimals
+                if (decimals < 1) return "^([1-9][0-9]{0,11}|0)$"; // e.g. 0-decimals ERC-20 tokens
                 var pattern = "^([1-9][0-9]{0,11}|0)(\\.[0-9]{0,%1}[1-9])?$";
-                return pattern.arg(currencies[currencyIdx].decimals - 1);
+                return pattern.arg(decimals - 1);
             }
 
             Connections {

--- a/ui/view/controls/FeeInput.qml
+++ b/ui/view/controls/FeeInput.qml
@@ -27,6 +27,14 @@ ColumnLayout {
     property string  rateUnit:                   ""
     property string  minimumFeeNotificationText: ""
 
+    // the recommended rate arrives asynchronously; adopt it if no fee is set
+    // yet and the user is not editing the field
+    onRecommendedFeeChanged: {
+        if (control.fee === 0 && control.recommendedFee > 0 && !control.readOnly && !feeInput.activeFocus) {
+            control.fee = BeamGlobals.getDefaultFee(control.currency)
+        }
+    }
+
     RowLayout {
         Layout.fillWidth: true
 

--- a/ui/view/controls/FeeInput.qml
+++ b/ui/view/controls/FeeInput.qml
@@ -75,16 +75,13 @@ ColumnLayout {
             }
         }
 
-        Item {
-            x: feeInput.width - feeCurrencyLabel.width - 8
-            y: 6
-            SFText {
-                id: feeCurrencyLabel
-                font.pixelSize: 14
-                color:          isValid ? Style.content_main : Style.validator_error
-                text:           control.feeLabel
-                visible:        (control.feeLabel || "").length
-            }
+        SFText {
+            id:               feeCurrencyLabel
+            Layout.alignment: Qt.AlignVCenter
+            font.pixelSize:   14
+            color:            isValid ? Style.content_main : Style.validator_error
+            text:             control.feeLabel
+            visible:          (control.feeLabel || "").length
         }
 
         Item {

--- a/ui/view/controls/SwapCurrencyAmountPane.qml
+++ b/ui/view/controls/SwapCurrencyAmountPane.qml
@@ -26,6 +26,9 @@ Rectangle {
     property alias amountWrapMode: amountField.wrapMode
     property var onClick: function() {}
     property string swapSettingsPane: ""
+    // custom-token cards have no static svg logo (item 4): a locally-generated
+    // colored-circle+letter icon is supplied here instead of currencyIcon
+    property Component iconDelegate: null
    
     id: control
     Layout.fillWidth: true
@@ -60,7 +63,14 @@ Rectangle {
                 source: currencyIcon
                 width: 26
                 height: 26
-                visible: currencyIcon.length
+                visible: currencyIcon.length && !control.iconDelegate
+            }
+
+            Loader {
+                anchors.verticalCenter: parent.verticalCenter
+                active: control.iconDelegate !== null
+                visible: active
+                sourceComponent: control.iconDelegate
             }
 
             Repeater {
@@ -135,7 +145,7 @@ Rectangle {
                 id:                clickArea
                 anchors.fill:      parent
                 acceptedButtons:   Qt.LeftButton
-                onClicked:         main.openSwapSettings(swapSettingsPane)
+                onClicked:         main.openSettings(swapSettingsPane)
                 hoverEnabled:      true
                 onPositionChanged: clickArea.cursorShape = Qt.PointingHandCursor;
             }

--- a/ui/view/controls/SwapEthSettings.qml
+++ b/ui/view/controls/SwapEthSettings.qml
@@ -7,7 +7,6 @@ import "../utils.js" as Utils
 
 SettingsFoldable {
     id:            control
-    height:        362
 
     property string generalTitle:             ""
     property alias  showSeedDialogTitle:      seedPhraseDialog.showSeedDialogTitle
@@ -31,6 +30,34 @@ SettingsFoldable {
 
     property string endpointCheckResult: ""
     property bool   endpointCheckOk:     false
+
+    // backing SwapEthSettingsItem, used directly for the custom-token flow
+    // rather than mirroring every field through property aliases + Connections
+    property var    ethSettings: undefined
+    property string newTokenSymbol:   ""
+    property int    newTokenDecimals: 0
+    property string newTokenError:    ""
+
+    function resetTokenLookup() {
+        newTokenSymbol   = ""
+        newTokenDecimals = 0
+        newTokenError    = ""
+    }
+    onUseCustomRpcChanged:    resetTokenLookup()
+    onCustomRpcUrlChanged:    resetTokenLookup()
+    onInfuraProjectIDChanged: resetTokenLookup()
+    // collapsing the section should not leave the token input focused/open underneath
+    onFoldedChanged: if (control.folded) addTokenPane.hide()
+
+    Connections {
+        target: ethSettings
+        function onTokenInfoReady(contract, symbol, decimals, error) {
+            if (contract !== newTokenAddress.text.trim()) return
+            newTokenSymbol   = symbol
+            newTokenDecimals = decimals
+            newTokenError    = error
+        }
+    }
 
     // function to get ethereum addresses
     property var   getEthereumAddresses:       undefined
@@ -257,7 +284,7 @@ SettingsFoldable {
             font.pixelSize: 12
             color:          Style.content_secondary
             wrapMode:       Text.Wrap
-            //% "Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node."
+            //% "Works with any Ethereum JSON-RPC endpoint. Keyless public options: ethereum-rpc.publicnode.com, eth.drpc.org, rpc.mevblocker.io - or run your own node."
             text:           qsTrId("settings-eth-rpc-note")
         }
 
@@ -385,15 +412,13 @@ SettingsFoldable {
             }
         }
 
-        // buttons
-        // "cancel" "apply"
-        // "connect to node" or "connect to electrum"
+        // check connection / cancel / apply / connect / disconnect - all on one centered row
         RowLayout {
             visible:                control.canChangeConnection
             Layout.preferredHeight: 52
             Layout.fillWidth:       true
             Layout.topMargin:       30
-            spacing:                15
+            spacing:                10
 
             Item {
                 Layout.fillWidth: true
@@ -401,9 +426,9 @@ SettingsFoldable {
 
             CustomButton {
                 Layout.preferredHeight: 38
-                Layout.preferredWidth:  164
-                leftPadding:  25
-                rightPadding: 25
+                Layout.preferredWidth:  160
+                leftPadding:  20
+                rightPadding: 20
                 //% "Check connection"
                 text:         qsTrId("settings-eth-check-connection")
                 // don't allow checking the last-applied endpoint while there are unapplied edits on screen
@@ -469,6 +494,7 @@ SettingsFoldable {
                 enabled:                isSettingsChanged() && canApplySettings()
                 onClicked:              applyChanges()
                 Layout.preferredHeight: 38
+                Layout.preferredWidth:  160
             }
 
             PrimaryButton {
@@ -481,7 +507,7 @@ SettingsFoldable {
                 icon.source:            "qrc:/assets/icon-done.svg"
                 onClicked:              connectToNode();
                 Layout.preferredHeight: 38
-                Layout.preferredWidth:  /*editElectrum ? 253 : */193
+                Layout.preferredWidth:  160
             }
 
             Item {
@@ -497,6 +523,173 @@ SettingsFoldable {
             wrapMode:         Text.Wrap
             color:            endpointCheckOk ? Style.active : Style.validator_error
             text:             (endpointCheckOk ? "✓ " : "✗ ") + endpointCheckResult
+        }
+
+        //
+        // Custom ERC-20 tokens (used as swap-offer receive currencies)
+        //
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: 30
+            spacing: 10
+            visible: control.ethSettings !== undefined && control.ethSettings !== null
+
+            SFText {
+                font.pixelSize: 14
+                color: control.color
+                //% "Custom ERC-20 tokens"
+                text: qsTrId("settings-swap-token-section-title")
+            }
+
+            // built in - always supported natively, can't be removed
+            Repeater {
+                model: control.ethSettings ? control.ethSettings.builtinTokens : []
+                delegate: RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+                    SvgImage {
+                        visible:    !!modelData.icon
+                        source:     modelData.icon ? modelData.icon : ""
+                        sourceSize: Qt.size(26, 26)
+                    }
+                    TokenIcon {
+                        visible:    !modelData.icon
+                        tokenColor: modelData.color
+                        symbol:     modelData.symbol
+                    }
+                    SFText {
+                        Layout.fillWidth: true
+                        font.pixelSize: 14
+                        color: Style.content_main
+                        elide: Text.ElideMiddle
+                        text: modelData.symbol + "  " + modelData.contract
+                    }
+                    SFText {
+                        font.pixelSize: 12
+                        color: control.color
+                        //% "built-in"
+                        text: qsTrId("settings-swap-token-builtin")
+                    }
+                }
+            }
+
+            // user-added
+            Repeater {
+                model: control.ethSettings ? control.ethSettings.customTokens : []
+                delegate: RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+                    TokenIcon {
+                        tokenColor: modelData.color
+                        symbol:     modelData.symbol
+                    }
+                    SFText {
+                        Layout.fillWidth: true
+                        font.pixelSize: 14
+                        color: Style.content_main
+                        elide: Text.ElideMiddle
+                        text: modelData.symbol + "  " + modelData.contract
+                    }
+                    LinkButton {
+                        //% "remove"
+                        text: qsTrId("settings-swap-token-remove")
+                        onClicked: control.ethSettings.removeCustomToken(modelData.contract)
+                    }
+                }
+            }
+
+            // "+ Add token" link; clicking it reveals the input row below
+            LinkButton {
+                visible:   !addTokenPane.visible
+                //% "+ Add token"
+                text:      qsTrId("settings-swap-token-add-open")
+                onClicked: {
+                    addTokenPane.visible = true
+                    newTokenAddress.forceActiveFocus()
+                }
+            }
+
+            ColumnLayout {
+                id:      addTokenPane
+                visible: false
+                Layout.fillWidth: true
+                spacing: 10
+
+                function hide() {
+                    addTokenPane.visible = false
+                    newTokenAddress.focus = false
+                    newTokenAddress.text = ""
+                    control.resetTokenLookup()
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+
+                    SFTextInput {
+                        id: newTokenAddress
+                        Layout.fillWidth: true
+                        font.pixelSize: 14
+                        color: Style.content_main
+                        underlineVisible: true
+                        //% "0x contract address"
+                        placeholderText: qsTrId("settings-swap-token-address-placeholder")
+                        onTextChanged: control.resetTokenLookup()
+                    }
+
+                    LinkButton {
+                        //% "cancel"
+                        text: qsTrId("settings-swap-token-add-cancel")
+                        onClicked: addTokenPane.hide()
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 15
+
+                    CustomButton {
+                        Layout.preferredHeight: 38
+                        leftPadding:  25
+                        rightPadding: 25
+                        //% "Look up"
+                        text: qsTrId("settings-swap-token-lookup")
+                        // the lookup queries the last-applied endpoint
+                        enabled: newTokenAddress.text.trim().length > 0 && !isSettingsChanged()
+                        onClicked: control.ethSettings.lookupToken(newTokenAddress.text.trim())
+                    }
+
+                    CustomButton {
+                        Layout.preferredHeight: 38
+                        leftPadding:  25
+                        rightPadding: 25
+                        //% "Add"
+                        text: qsTrId("settings-swap-token-add")
+                        enabled: newTokenSymbol.length > 0
+                        onClicked: {
+                            control.ethSettings.addCustomToken(newTokenAddress.text.trim(), newTokenSymbol, newTokenDecimals)
+                            // the rejection error is emitted synchronously
+                            if (newTokenError.length === 0)
+                                addTokenPane.hide()
+                        }
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                }
+
+                SFText {
+                    visible: newTokenSymbol.length > 0 || newTokenError.length > 0
+                    Layout.fillWidth: true
+                    font.pixelSize: 12
+                    wrapMode: Text.Wrap
+                    color: newTokenError.length > 0 ? Style.validator_error : Style.content_secondary
+                    text: newTokenError.length > 0 ? newTokenError :
+                        //% "%1, %2 decimals"
+                        qsTrId("settings-swap-token-info").arg(newTokenSymbol).arg(newTokenDecimals)
+                }
+            }
         }
     }
 }

--- a/ui/view/controls/SwapEthSettings.qml
+++ b/ui/view/controls/SwapEthSettings.qml
@@ -22,10 +22,15 @@ SettingsFoldable {
 
     property alias  infuraProjectID:      infuraProjectIDInput.text
     property alias  accountIndex:         accountIndexInput.text
+    property alias  useCustomRpc:         useCustomRpcSwitch.checked
+    property alias  customRpcUrl:         customRpcUrlInput.text
 
     property alias seedPhrases:        seedPhraseDialog.seedPhrasesElectrum
     property alias phrasesSeparator:   seedPhraseDialog.phrasesSeparatorElectrum
     property bool  isCurrentSeedValid: false
+
+    property string endpointCheckResult: ""
+    property bool   endpointCheckOk:     false
 
     // function to get ethereum addresses
     property var   getEthereumAddresses:       undefined
@@ -61,12 +66,15 @@ SettingsFoldable {
     signal restoreSeedPhrases
     signal copySeedPhrases
     signal validateCurrentSeedPhrase
+    signal validateEndpoint
 
     QtObject {
         id: internalValues
         property string initialInfuraProjectID
         property string initialSeed
         property string initialAccountIndex
+        property bool   initialUseCustomRpc
+        property string initialCustomRpcUrl
 
         property bool   isSeedChanged: false
 
@@ -76,16 +84,21 @@ SettingsFoldable {
             control.restoreSeedPhrases()
 
             accountIndex = initialAccountIndex
+            useCustomRpc = initialUseCustomRpc
+            customRpcUrl = initialCustomRpcUrl
         }
 
         function save() {
             initialInfuraProjectID = infuraProjectID
             isSeedChanged = false
             initialAccountIndex = accountIndex
+            initialUseCustomRpc = useCustomRpc
+            initialCustomRpcUrl = customRpcUrl
         }
 
         function isChanged() {
-            return initialInfuraProjectID !== infuraProjectID || isSeedChanged ||initialAccountIndex != accountIndex
+            return initialInfuraProjectID !== infuraProjectID || isSeedChanged || initialAccountIndex != accountIndex ||
+                   initialUseCustomRpc !== useCustomRpc || initialCustomRpcUrl !== customRpcUrl
         }
     }
 
@@ -134,6 +147,41 @@ SettingsFoldable {
     content: ColumnLayout {
         spacing: 0
 
+        // Infura & Custom RPC switch
+        RowLayout {
+            height:   20
+            spacing:  10
+            Layout.fillWidth: true
+            SFText {
+                //% "Infura"
+                text:  qsTrId("settings-eth-infura")
+                color: useCustomRpcSwitch.checked ? control.color : Style.active
+                font.pixelSize: 14
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    onClicked: useCustomRpcSwitch.checked = !useCustomRpcSwitch.checked
+                }
+            }
+            CustomSwitch {
+                id:          useCustomRpcSwitch
+                alwaysGreen: true
+                spacing:     0
+                enabled:     canEdit
+            }
+            SFText {
+                //% "Custom RPC"
+                text: qsTrId("settings-eth-custom-rpc")
+                color: useCustomRpcSwitch.checked ? Style.active : control.color
+                font.pixelSize: 14
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    onClicked: useCustomRpcSwitch.checked = !useCustomRpcSwitch.checked
+                }
+            }
+        }
+
         GridLayout {
             Layout.topMargin: 20
             columns:          2
@@ -141,6 +189,7 @@ SettingsFoldable {
             rowSpacing:       13
 
             SFText {
+                visible:        !useCustomRpcSwitch.checked
                 font.pixelSize: 14
                 color:          control.color
                 //% "Infura project ID"
@@ -149,6 +198,7 @@ SettingsFoldable {
 
             SFTextInput {
                 id:               infuraProjectIDInput
+                visible:          !useCustomRpcSwitch.checked
                 Layout.fillWidth: true
                 color:            Style.content_main
                 font.pixelSize:     14
@@ -177,6 +227,38 @@ SettingsFoldable {
                     top: 20
                 }
             }
+        }
+
+        SFText {
+            visible:        useCustomRpcSwitch.checked
+            Layout.topMargin: 20
+            font.pixelSize: 14
+            color:          control.color
+            //% "Ethereum RPC endpoint"
+            text:           qsTrId("settings-eth-rpc-endpoint")
+        }
+
+        SFTextInput {
+            id:               customRpcUrlInput
+            visible:          useCustomRpcSwitch.checked
+            Layout.fillWidth: true
+            color:            Style.content_main
+            font.pixelSize:   14
+            activeFocusOnTab: true
+            underlineVisible: canEdit
+            readOnly:         !canEdit
+            placeholderText:  "https://mainnet.infura.io/v3/..."
+        }
+
+        SFText {
+            visible:        useCustomRpcSwitch.checked
+            Layout.fillWidth: true
+            Layout.topMargin: 7
+            font.pixelSize: 12
+            color:          Style.content_secondary
+            wrapMode:       Text.Wrap
+            //% "Supports Infura, Alchemy, QuickNode, Chainstack, Ankr, or your own Ethereum node."
+            text:           qsTrId("settings-eth-rpc-note")
         }
 
         // seed: new || edit
@@ -318,6 +400,18 @@ SettingsFoldable {
             }
 
             CustomButton {
+                Layout.preferredHeight: 38
+                Layout.preferredWidth:  164
+                leftPadding:  25
+                rightPadding: 25
+                //% "Check connection"
+                text:         qsTrId("settings-eth-check-connection")
+                // don't allow checking the last-applied endpoint while there are unapplied edits on screen
+                enabled:      (isConnected || canApplySettings()) && !isSettingsChanged()
+                onClicked:    validateEndpoint()
+            }
+
+            CustomButton {
                 visible:                applySettingsButtonId.visible
                 Layout.preferredHeight: 38
                 Layout.preferredWidth:  130
@@ -393,6 +487,16 @@ SettingsFoldable {
             Item {
                 Layout.fillWidth: true
             }
+        }
+
+        SFText {
+            visible:          endpointCheckResult !== ""
+            Layout.fillWidth: true
+            Layout.topMargin: 10
+            font.pixelSize:   14
+            wrapMode:         Text.Wrap
+            color:            endpointCheckOk ? Style.active : Style.validator_error
+            text:             (endpointCheckOk ? "✓ " : "✗ ") + endpointCheckResult
         }
     }
 }

--- a/ui/view/controls/SwapEthSettings.qml
+++ b/ui/view/controls/SwapEthSettings.qml
@@ -28,8 +28,10 @@ SettingsFoldable {
     property alias phrasesSeparator:   seedPhraseDialog.phrasesSeparatorElectrum
     property bool  isCurrentSeedValid: false
 
-    property string endpointCheckResult: ""
-    property bool   endpointCheckOk:     false
+    // read-only feedback from the last "check connection" run; bound straight
+    // to the viewmodel so no push-mirroring is needed
+    readonly property string endpointCheckResult: ethSettings ? ethSettings.endpointCheckResult : ""
+    readonly property bool   endpointCheckOk:     ethSettings ? !!ethSettings.endpointCheckOk : false
 
     // backing SwapEthSettingsItem, used directly for the custom-token flow
     // rather than mirroring every field through property aliases + Connections

--- a/ui/view/controls/SwapTokenInfoDialog.qml
+++ b/ui/view/controls/SwapTokenInfoDialog.qml
@@ -63,7 +63,7 @@ CustomDialog {
                 Layout.alignment:       Qt.AlignTop
                 font.pixelSize:         14
                 color:                  Style.content_disabled
-                text:                   qsTrId("sent-amount-label") + ":"
+                text:                   qsTrId("atomic-swap-i-send") + ":"
                 visible:                viewModel.sendAmount.length
             }
 
@@ -82,7 +82,7 @@ CustomDialog {
                 Layout.alignment:       Qt.AlignTop
                 font.pixelSize:         14
                 color:                  Style.content_disabled
-                text:                   qsTrId("receive-amount-swap-label") + ":"
+                text:                   qsTrId("atomic-swap-i-receive") + ":"
                 visible:                viewModel.receiveAmount.length
             }
 

--- a/ui/view/controls/SwapTransactionDetails.qml
+++ b/ui/view/controls/SwapTransactionDetails.qml
@@ -37,6 +37,7 @@ RowLayout {
     property var    swapCoinRefundTxConfirmations
 
     property var    stateDetails
+    property var    coinsUnlockNote
 
     // property var onOpenExternal: null
     signal textCopied(string text)
@@ -361,6 +362,26 @@ RowLayout {
                 wrapMode: Text.Wrap
                 elide: Text.ElideMiddle
                 text: root.stateDetails
+                onCopyText: textCopied(text)
+            }
+        }
+
+        RowLayout {
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+            visible: root.coinsUnlockNote != ""
+            SvgImage {
+                sourceSize: Qt.size(16, 16)
+                source:  "qrc:/assets/icon-attention.svg"
+            }
+            SFLabel {
+                Layout.fillWidth: true
+                copyMenuEnabled: true
+                font.pixelSize: 14
+                color: Style.content_main
+                wrapMode: Text.Wrap
+                elide: Text.ElideMiddle
+                text: root.coinsUnlockNote
                 onCopyText: textCopied(text)
             }
         }

--- a/ui/view/controls/TokenIcon.qml
+++ b/ui/view/controls/TokenIcon.qml
@@ -1,0 +1,33 @@
+import QtQuick
+import "."
+
+// Deterministic, local-only colored-circle icon for an ERC-20 token, matching the
+// look of Confidential Asset icons (colored circle + glyph) without any network
+// lookup: the color is a hash of the contract address (see beamui::ColorFromString),
+// the glyph is just the token symbol's first letter.
+Item {
+    id: control
+
+    property color  tokenColor: "#8192a3"
+    property string symbol:     ""
+    property int    size:       26
+
+    width:          size
+    height:         size
+    implicitWidth:  size
+    implicitHeight: size
+
+    Rectangle {
+        anchors.fill: parent
+        radius:       width / 2
+        color:        control.tokenColor
+    }
+
+    SFText {
+        anchors.centerIn: parent
+        text:             control.symbol.length ? control.symbol.charAt(0).toUpperCase() : "?"
+        color:            "white"
+        font.pixelSize:   control.size * 0.42
+        font.bold:        true
+    }
+}

--- a/ui/view/create_asset_swap.qml
+++ b/ui/view/create_asset_swap.qml
@@ -55,8 +55,8 @@ ColumnLayout {
                     // Send amount
                     //
                     Panel {
-                        //% "Send amount"
-                        title:                   qsTrId("sent-amount-label")
+                        //% "I send"
+                        title:                   qsTrId("atomic-swap-i-send")
                         Layout.fillWidth:        true
                         content:
                         AmountInput {
@@ -147,8 +147,8 @@ ColumnLayout {
                     // Receive amount
                     //
                     Panel {
-                        //% "Receive amount"
-                        title: qsTrId("receive-amount-swap-label")
+                        //% "I receive"
+                        title: qsTrId("atomic-swap-i-receive")
                         Layout.fillWidth:        true
                         content:
                         AmountInput {

--- a/ui/view/create_atomic_swap.qml
+++ b/ui/view/create_atomic_swap.qml
@@ -115,8 +115,8 @@ Update your settings and try again."
                     // Send amount
                     //
                     Panel {
-                        //% "Send amount"
-                        title:                   qsTrId("sent-amount-label")
+                        //% "I send"
+                        title:                   qsTrId("atomic-swap-i-send")
                         Layout.fillWidth:        true
                         content:
                         AmountInput {
@@ -348,8 +348,8 @@ please review your settings and try again"
                     // Receive amount
                     //
                     Panel {
-                        //% "Receive amount"
-                        title: qsTrId("receive-amount-swap-label")
+                        //% "I receive"
+                        title: qsTrId("atomic-swap-i-receive")
                         Layout.fillWidth: true
                         content:
                         AmountInput {

--- a/ui/view/create_atomic_swap.qml
+++ b/ui/view/create_atomic_swap.qml
@@ -207,7 +207,8 @@ please review your settings and try again"
                             currency:                 viewModel.sentCurrency
                             minFee:                   currency == OldWalletCurrency.CurrBeam ? viewModel.minimalBeamFeeGrothes : BeamGlobals.getMinimalFee(currency, false)
                             maxFee:                     BeamGlobals.getMaximumFee(currency)
-                            recommendedFee:           BeamGlobals.getRecommendedFee(currency)
+                            // feeRatesRevision makes the binding re-query the cached rate
+                            recommendedFee:           { viewModel.feeRatesRevision; return BeamGlobals.getRecommendedFee(currency); }
                             feeLabel:                 BeamGlobals.getFeeRateLabel(currency)
                             color:                    Style.accent_outgoing
                             readOnly:                 false
@@ -437,7 +438,7 @@ please review your settings and try again"
                             currency:                   viewModel.receiveCurrency
                             minFee:                     BeamGlobals.getMinimalFee(currency, false)
                             maxFee:                     BeamGlobals.getMaximumFee(currency)
-                            recommendedFee:             BeamGlobals.getRecommendedFee(currency)
+                            recommendedFee:             { viewModel.feeRatesRevision; return BeamGlobals.getRecommendedFee(currency); }
                             feeLabel:                   BeamGlobals.getFeeRateLabel(currency)
                             color:                      Style.accent_outgoing
                             readOnly:                   false

--- a/ui/view/create_atomic_swap.qml
+++ b/ui/view/create_atomic_swap.qml
@@ -400,8 +400,11 @@ please review your settings and try again"
                                     return qsTrId("send-less-than-fee")
                                 }
                                 if(!viewModel.isEnoughToReceive) {
-                                    //% "There is not enough funds to complete the transaction"
-                                    return qsTrId("send-not-enough")
+                                    // isEnoughToReceive only fails for an Ethereum-based receive
+                                    // side: the redeem tx gas is paid in ETH
+/*% "Not enough ETH to pay the redeem transaction fee (%1 needed)"
+*/
+                                    return qsTrId("swap-not-enough-eth-redeem").arg(BeamGlobals.calcWithdrawTxFee(viewModel.receiveCurrency, viewModel.receiveFee))
                                 }
                                 return ""
                             }

--- a/ui/view/create_atomic_swap.qml
+++ b/ui/view/create_atomic_swap.qml
@@ -32,6 +32,29 @@ ColumnLayout {
         }
     }
 
+    // currencyIdx is a plain int property: the first imperative write to it
+    // (combo onActivated, swap-arrow, Beam-invariant enforcement) destroys the
+    // declarative "currencyIdx: viewModel.sentCurrencyIndex" binding. Resync
+    // manually whenever the VM re-derives the index (e.g. currList mutated by
+    // adding/removing a token in settings).
+    Connections {
+        target: viewModel
+        function onCurrListChanged() {
+            if (sentAmountInput.currencyIdx !== viewModel.sentCurrencyIndex)
+                sentAmountInput.currencyIdx = viewModel.sentCurrencyIndex
+            if (receiveAmountInput.currencyIdx !== viewModel.receiveCurrencyIndex)
+                receiveAmountInput.currencyIdx = viewModel.receiveCurrencyIndex
+        }
+        function onSentCurrencyIndexChanged() {
+            if (sentAmountInput.currencyIdx !== viewModel.sentCurrencyIndex)
+                sentAmountInput.currencyIdx = viewModel.sentCurrencyIndex
+        }
+        function onReceiveCurrencyIndexChanged() {
+            if (receiveAmountInput.currencyIdx !== viewModel.receiveCurrencyIndex)
+                receiveAmountInput.currencyIdx = viewModel.receiveCurrencyIndex
+        }
+    }
+
     SwapTokenInfoDialog {
         id:               tokenInfoDialog
         token:            viewModel.transactionToken
@@ -123,21 +146,21 @@ Update your settings and try again."
                             id:                         sentAmountInput
                             color:                      Style.accent_outgoing
                             currencies:                 viewModel.currList
-                            currencyIdx:                viewModel.sentCurrency
+                            currencyIdx:                viewModel.sentCurrencyIndex
                             amount:                     viewModel.amountSent
                             rate:                       viewModel.secondCurrencySendRateValue
                             rateUnit:                   viewModel.secondCurrencyUnitName
                             multi:                      true
                             resetAmount:                false
-                            currColor:                  currencyError() || !BeamGlobals.canReceive(currencyIdx) ? Style.validator_error : Style.content_main
+                            currColor:                  currencyError() || !BeamGlobals.canReceive(viewModel.sentCurrency) ? Style.validator_error : Style.content_main
                             error:                      getErrorText()
 
                             function getErrorText() {
-                                if(!BeamGlobals.canReceive(currencyIdx)) {
+                                if(!BeamGlobals.canReceive(viewModel.sentCurrency)) {
 /*% "%1 is not connected, 
 please review your settings and try again"
 */
-                                    return qsTrId("swap-currency-na-message").arg(BeamGlobals.getCurrencyName(currencyIdx)).replace("\n", "")
+                                    return qsTrId("swap-currency-na-message").arg(BeamGlobals.getCurrencyName(viewModel.sentCurrency)).replace("\n", "")
                                 }
                                 if(!viewModel.isSendFeeOK) {
                                     //% "The swap amount must be greater than the transaction fee"
@@ -151,8 +174,8 @@ please review your settings and try again"
                             }
 
                             onCurrencyIdxChanged: {
-                                if(sentAmountInput.currencyIdx != OldWalletCurrency.CurrBeam &&
-                                   receiveAmountInput.currencyIdx != OldWalletCurrency.CurrBeam) {
+                                // asset entries are BEAM-side too, so key on isBEAM, not the index
+                                if(!sentAmountInput.isBeam && !receiveAmountInput.isBeam) {
                                     receiveAmountInput.currencyIdx = OldWalletCurrency.CurrBeam
                                 }
                             }
@@ -166,7 +189,7 @@ please review your settings and try again"
 
                         Binding {
                             target:   viewModel
-                            property: "sentCurrency"
+                            property: "sentCurrencyIndex"
                             value:    sentAmountInput.currencyIdx
                         }
                     }
@@ -355,21 +378,21 @@ please review your settings and try again"
                         AmountInput {
                             id:             receiveAmountInput
                             currencies:     viewModel.currList
-                            currencyIdx:    viewModel.receiveCurrency
+                            currencyIdx:    viewModel.receiveCurrencyIndex
                             amount:         viewModel.amountToReceive
                             rate:           viewModel.secondCurrencyReceiveRateValue
                             rateUnit:       viewModel.secondCurrencyUnitName
                             multi:          true
                             resetAmount:    false
-                            currColor:      currencyError() || !BeamGlobals.canReceive(currencyIdx) ? Style.validator_error : Style.content_main
+                            currColor:      currencyError() || !BeamGlobals.canReceive(viewModel.receiveCurrency) ? Style.validator_error : Style.content_main
                             error:          getErrorText()
 
                             function getErrorText() {
-                                if(!BeamGlobals.canReceive(currencyIdx)) {
+                                if(!BeamGlobals.canReceive(viewModel.receiveCurrency)) {
 /*% "%1 is not connected, 
 please review your settings and try again"
 */
-                                    return qsTrId("swap-currency-na-message").arg(BeamGlobals.getCurrencyName(currencyIdx)).replace("\n", "")
+                                    return qsTrId("swap-currency-na-message").arg(BeamGlobals.getCurrencyName(viewModel.receiveCurrency)).replace("\n", "")
                                 }
                                 if(!viewModel.isReceiveFeeOK) {
                                     //% "The swap amount must be greater than the transaction fee"
@@ -383,8 +406,7 @@ please review your settings and try again"
                             }
 
                             onCurrencyIdxChanged: {
-                                if(receiveAmountInput.currencyIdx != OldWalletCurrency.CurrBeam &&
-                                   sentAmountInput.currencyIdx != OldWalletCurrency.CurrBeam) {
+                                if(!receiveAmountInput.isBeam && !sentAmountInput.isBeam) {
                                     sentAmountInput.currencyIdx = OldWalletCurrency.CurrBeam
                                 }
                             }
@@ -398,7 +420,7 @@ please review your settings and try again"
 
                         Binding {
                             target:   viewModel
-                            property: "receiveCurrency"
+                            property: "receiveCurrencyIndex"
                             value:    receiveAmountInput.currencyIdx
                         }
                     }

--- a/ui/view/qml.qrc
+++ b/ui/view/qml.qrc
@@ -10,6 +10,7 @@
         <file>controls/qmldir</file>
         <file>controls/SvgImage.qml</file>
         <file>controls/SwapCurrencyAmountPane.qml</file>
+        <file>controls/TokenIcon.qml</file>
         <file>controls/SFLabel.qml</file>
         <file>controls/SFText.qml</file>
         <file>controls/SFTextInput.qml</file>

--- a/ui/view/send_swap.qml
+++ b/ui/view/send_swap.qml
@@ -367,8 +367,11 @@ please review your settings and try again"
                                     return qsTrId("send-less-than-fee")
                                 }
                                 if(!viewModel.isEnoughToReceive) {
-                                    //% "There is not enough funds to complete the transaction"
-                                    return qsTrId("send-not-enough")
+                                    // isEnoughToReceive only fails for an Ethereum-based receive
+                                    // side: the redeem tx gas is paid in ETH
+/*% "Not enough ETH to pay the redeem transaction fee (%1 needed)"
+*/
+                                    return qsTrId("swap-not-enough-eth-redeem").arg(BeamGlobals.calcWithdrawTxFee(viewModel.receiveCurrency, viewModel.receiveFee))
                                 }
                                 return ""
                             }

--- a/ui/view/send_swap.qml
+++ b/ui/view/send_swap.qml
@@ -141,8 +141,8 @@ please review your settings and try again"
                     // Send amount
                     //
                     Panel {
-                        //% "Send amount"
-                        title:                   qsTrId("sent-amount-label")
+                        //% "I send"
+                        title:                   qsTrId("atomic-swap-i-send")
                         Layout.fillWidth:        true
 
                         content:
@@ -265,8 +265,8 @@ please review your settings and try again"
                     // Receive amount
                     //
                     Panel {
-                        //% "Receive amount"
-                        title:                   qsTrId("receive-amount-swap-label")
+                        //% "I receive"
+                        title:                   qsTrId("atomic-swap-i-receive")
                         Layout.fillWidth:        true
                         content:
 

--- a/ui/view/send_swap.qml
+++ b/ui/view/send_swap.qml
@@ -251,6 +251,84 @@ please review your settings and try again"
                             }
                         }
                     }
+
+                    //
+                    // ERC-20 token details
+                    //
+                    FoldablePanel {
+                        visible:                 viewModel.isErc20Swap
+                        //% "Token"
+                        title:                   qsTrId("swap-accept-token-title")
+                        Layout.fillWidth:        true
+
+                        content: ColumnLayout {
+                            SFText {
+                                font.pixelSize:   14
+                                color:            Style.content_secondary
+                                //% "Contract address"
+                                text:             qsTrId("swap-accept-token-contract-label")
+                            }
+                            SFLabel {
+                                Layout.fillWidth:    true
+                                font.pixelSize:      14
+                                font.family:         "Monospace"
+                                color:               Style.content_main
+                                wrapMode:            Text.WrapAnywhere
+                                copyMenuEnabled:     true
+                                text:                viewModel.tokenContract
+                            }
+                            SFText {
+                                Layout.topMargin: 10
+                                font.pixelSize:   14
+                                color:            Style.content_secondary
+                                //% "Symbol / decimals"
+                                text:             qsTrId("swap-accept-token-symbol-label")
+                            }
+                            SFText {
+                                font.pixelSize: 14
+                                color:          Style.content_main
+                                text:           viewModel.tokenSymbol + " / " + viewModel.tokenDecimals
+                            }
+                            SFText {
+                                Layout.topMargin:  10
+                                Layout.fillWidth:  true
+                                font.pixelSize:    12
+                                color:             Style.validator_error
+                                wrapMode:          Text.Wrap
+                                //% "Verify this token contract address carefully. Anyone can create a token with any name."
+                                text:              qsTrId("swap-accept-token-warning")
+                            }
+                        }
+                    }
+
+                    //
+                    // Confidential Asset details
+                    //
+                    FoldablePanel {
+                        visible:                 viewModel.isBeamAssetSwap
+                        //% "Confidential Asset"
+                        title:                   qsTrId("swap-accept-asset-title")
+                        Layout.fillWidth:        true
+
+                        content: ColumnLayout {
+                            SFText {
+                                font.pixelSize: 14
+                                color:          Style.content_main
+                                //% "Asset id %1, unit %2"
+                                text:           qsTrId("swap-accept-asset-id-unit").arg(viewModel.beamAssetId).arg(viewModel.beamAssetUnitName)
+                            }
+                            SFText {
+                                visible:           viewModel.needsBeamForRedeemFee
+                                Layout.topMargin:  10
+                                Layout.fillWidth:  true
+                                font.pixelSize:    12
+                                color:             Style.content_secondary
+                                wrapMode:          Text.Wrap
+                                //% "You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee."
+                                text:              qsTrId("swap-accept-asset-beam-fee")
+                            }
+                        }
+                    }
                 }
 
                 //
@@ -506,6 +584,14 @@ please review your settings and try again"
                             flatFee:        viewModel.sendCurrency == OldWalletCurrency.CurrBeam,
                             rate:           viewModel.secondCurrencySendRateValue,
                             rateUnit:       viewModel.secondCurrencyUnitName,
+                            isErc20Swap:           viewModel.isErc20Swap,
+                            tokenContract:         viewModel.tokenContract,
+                            tokenSymbol:           viewModel.tokenSymbol,
+                            tokenDecimals:         viewModel.tokenDecimals,
+                            isBeamAssetSwap:       viewModel.isBeamAssetSwap,
+                            beamAssetId:           viewModel.beamAssetId,
+                            beamAssetUnitName:     viewModel.beamAssetUnitName,
+                            needsBeamForRedeemFee: viewModel.needsBeamForRedeemFee,
                         })
 
                     dialogObject.onAccepted.connect(function () {

--- a/ui/view/send_swap.qml
+++ b/ui/view/send_swap.qml
@@ -199,7 +199,7 @@ please review your settings and try again"
                             currency:                   viewModel.sendCurrency
                             minFee:                     currency == OldWalletCurrency.CurrBeam ? viewModel.minimalBeamFeeGrothes : BeamGlobals.getMinimalFee(currency, false)
                             maxFee:                     BeamGlobals.getMaximumFee(currency)
-                            recommendedFee:             BeamGlobals.getRecommendedFee(currency)
+                            recommendedFee:             { viewModel.feeRatesRevision; return BeamGlobals.getRecommendedFee(currency); }
                             feeLabel:                   BeamGlobals.getFeeRateLabel(currency)
                             color:                      Style.accent_outgoing
                             readOnly:                   false
@@ -400,7 +400,7 @@ please review your settings and try again"
                             currency:                   viewModel.receiveCurrency
                             minFee:                     BeamGlobals.getMinimalFee(currency, false)
                             maxFee:                     BeamGlobals.getMaximumFee(currency)
-                            recommendedFee:             BeamGlobals.getRecommendedFee(currency)
+                            recommendedFee:             { viewModel.feeRatesRevision; return BeamGlobals.getRecommendedFee(currency); }
                             feeLabel:                   BeamGlobals.getFeeRateLabel(currency)
                             color:                      Style.accent_outgoing
                             readOnly:                   false

--- a/ui/view/swap_confirm.qml
+++ b/ui/view/swap_confirm.qml
@@ -35,6 +35,16 @@ ConfirmationDialog {
     property string rateUnit:  ""
     property bool   showRate:  rateUnit.length > 0
 
+    // CA / ERC-20 extended offer info, set by the caller (send_swap.qml)
+    property bool   isErc20Swap:           false
+    property string tokenContract:         ""
+    property string tokenSymbol:           ""
+    property int    tokenDecimals:         0
+    property bool   isBeamAssetSwap:       false
+    property int    beamAssetId:           0
+    property string beamAssetUnitName:     ""
+    property bool   needsBeamForRedeemFee: false
+
     readonly property string feeLabel: {
         //% "Fee"
         if (!control.swapMode) return [qsTrId("send-regular-fee"), ":"].join("")
@@ -281,6 +291,33 @@ ConfirmationDialog {
                 color:                  Style.content_disabled
                 wrapMode:               Text.WordWrap
                 text:                   control.onlineMessage
+            }
+
+            //
+            // ERC-20 token / Confidential Asset confirmation notes
+            //
+            SFText {
+                visible:                control.isErc20Swap
+                Layout.columnSpan:      2
+                horizontalAlignment:    Text.AlignHCenter
+                Layout.fillWidth:       true
+                font.pixelSize:         12
+                color:                  Style.validator_error
+                wrapMode:               Text.WordWrap
+                //% "%1 contract: %2. Verify this token contract address carefully. Anyone can create a token with any name."
+                text:                   qsTrId("swap-accept-token-warning-confirm").arg(control.tokenSymbol).arg(control.tokenContract)
+            }
+
+            SFText {
+                visible:                control.needsBeamForRedeemFee
+                Layout.columnSpan:      2
+                horizontalAlignment:    Text.AlignHCenter
+                Layout.fillWidth:       true
+                font.pixelSize:         12
+                color:                  Style.content_disabled
+                wrapMode:               Text.WordWrap
+                //% "You are receiving a Confidential Asset. A small BEAM balance is required to pay the redeem transaction fee."
+                text:                   qsTrId("swap-accept-asset-beam-fee")
             }
         }
     }

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
@@ -131,7 +131,7 @@ QString SwapEthSettingsItem::getTitle() const
 {
     if (m_settings->m_shouldConnect)
     {
-        //% "Ethereum node"
+        //% "Ethereum"
         return qtTrId("settings-swap-ethereum-node");
     }
     

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
@@ -42,7 +42,7 @@ SwapEthSettingsItem::SwapEthSettingsItem()
     connect(coinClient.get(), SIGNAL(statusChanged()), this, SIGNAL(connectionStatusChanged()));
     connect(coinClient.get(), SIGNAL(connectionErrorChanged()), this, SIGNAL(connectionErrorChanged()));
     connect(coinClient.get(), &SwapEthClientModel::endpointValidated, this, &SwapEthSettingsItem::onEndpointValidated);
-    connect(coinClient.get(), &SwapEthClientModel::gotTokenInfo, this, &SwapEthSettingsItem::onGotTokenInfo);
+    connect(coinClient.get(), &SwapEthClientModel::gotTokenInfo, this, &SwapEthSettingsItem::tokenInfoReady);
     LoadSettings();
     loadCustomTokens();
 }
@@ -143,11 +143,6 @@ void SwapEthSettingsItem::lookupToken(const QString& contractAddress)
     {
         c->requestTokenInfo(address);
     }
-}
-
-void SwapEthSettingsItem::onGotTokenInfo(const QString& contract, const QString& symbol, uint decimals, const QString& error)
-{
-    emit tokenInfoReady(contract, symbol, decimals, error);
 }
 
 void SwapEthSettingsItem::addCustomToken(const QString& contractAddress, const QString& symbol, uint decimals)

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
@@ -22,8 +22,11 @@
 #include "viewmodel/qml_globals.h"
 #include "seed_phrase_item.h"
 #include "viewmodel/settings_helpers.h"
+#include "viewmodel/ui_helpers.h"
 
 #include "wallet/transactions/swaps/bridges/ethereum/common.h"
+#include "wallet/transactions/swaps/common.h"
+#include "model/settings.h"
 
 using namespace beam;
 
@@ -39,7 +42,9 @@ SwapEthSettingsItem::SwapEthSettingsItem()
     connect(coinClient.get(), SIGNAL(statusChanged()), this, SIGNAL(connectionStatusChanged()));
     connect(coinClient.get(), SIGNAL(connectionErrorChanged()), this, SIGNAL(connectionErrorChanged()));
     connect(coinClient.get(), &SwapEthClientModel::endpointValidated, this, &SwapEthSettingsItem::onEndpointValidated);
+    connect(coinClient.get(), &SwapEthClientModel::gotTokenInfo, this, &SwapEthSettingsItem::onGotTokenInfo);
     LoadSettings();
+    loadCustomTokens();
 }
 
 SwapEthSettingsItem::~SwapEthSettingsItem()
@@ -122,6 +127,132 @@ void SwapEthSettingsItem::validateEndpoint()
     {
         c->validateEndpoint();
     }
+}
+
+void SwapEthSettingsItem::lookupToken(const QString& contractAddress)
+{
+    const auto address = contractAddress.trimmed().toStdString();
+    if (!wallet::IsValidEthContractAddress(address))
+    {
+        //% "Invalid contract address"
+        emit tokenInfoReady(contractAddress, QString(), 0, qtTrId("settings-swap-token-invalid-address"));
+        return;
+    }
+
+    if (auto c = m_coinClient.lock())
+    {
+        c->requestTokenInfo(address);
+    }
+}
+
+void SwapEthSettingsItem::onGotTokenInfo(const QString& contract, const QString& symbol, uint decimals, const QString& error)
+{
+    emit tokenInfoReady(contract, symbol, decimals, error);
+}
+
+void SwapEthSettingsItem::addCustomToken(const QString& contractAddress, const QString& symbol, uint decimals)
+{
+    const auto address = contractAddress.trimmed().toStdString();
+    if (!wallet::IsValidEthContractAddress(address) || symbol.isEmpty())
+    {
+        return;
+    }
+
+    const auto normalized = QString::fromStdString(address).toLower();
+    if (isBuiltinTokenContract(normalized))
+    {
+        //% "This token is already supported"
+        emit tokenInfoReady(contractAddress, QString(), 0, qtTrId("settings-swap-token-already-added"));
+        return;
+    }
+    for (const auto& token : m_customTokens)
+    {
+        if (token.value("contract").toString().toLower() == normalized)
+        {
+            //% "This token is already supported"
+            emit tokenInfoReady(contractAddress, QString(), 0, qtTrId("settings-swap-token-already-added"));
+            return; // already added
+        }
+    }
+
+    QMap<QString, QVariant> token;
+    token.insert("contract", QString::fromStdString(address));
+    token.insert("symbol", symbol);
+    token.insert("decimals", decimals);
+    m_customTokens.push_back(token);
+
+    saveCustomTokens();
+    emit customTokensChanged();
+}
+
+void SwapEthSettingsItem::removeCustomToken(const QString& contractAddress)
+{
+    const auto normalized = contractAddress.trimmed().toLower();
+    for (int i = 0; i < m_customTokens.size(); ++i)
+    {
+        if (m_customTokens[i].value("contract").toString().toLower() == normalized)
+        {
+            m_customTokens.removeAt(i);
+            saveCustomTokens();
+            emit customTokensChanged();
+            return;
+        }
+    }
+}
+
+QList<QMap<QString, QVariant>> SwapEthSettingsItem::getCustomTokens() const
+{
+    QList<QMap<QString, QVariant>> result;
+    for (auto token : m_customTokens)
+    {
+        token.insert("color", beamui::ColorFromString(token.value("contract").toString()));
+        result.push_back(token);
+    }
+    return result;
+}
+
+QList<QMap<QString, QVariant>> SwapEthSettingsItem::getBuiltinTokens() const
+{
+    QList<QMap<QString, QVariant>> result;
+    static const std::tuple<wallet::AtomicSwapCoin, const char*, const char*> builtins[] = {
+        { wallet::AtomicSwapCoin::Usdt, "USDT", "qrc:/assets/icon-usdt.svg" },
+        { wallet::AtomicSwapCoin::Dai,  "DAI",  "qrc:/assets/icon-dai.svg" },
+        { wallet::AtomicSwapCoin::WBTC, "WBTC", "qrc:/assets/icon-wbtc.svg" },
+    };
+
+    for (const auto& [coin, symbol, icon] : builtins)
+    {
+        QMap<QString, QVariant> token;
+        const auto contract = QString::fromStdString(m_settings->GetTokenContractAddress(coin));
+        token.insert("symbol", QString(symbol));
+        token.insert("contract", contract);
+        token.insert("color", beamui::ColorFromString(contract));
+        token.insert("icon", QString(icon));
+        result.push_back(token);
+    }
+    return result;
+}
+
+bool SwapEthSettingsItem::isBuiltinTokenContract(const QString& normalizedAddress) const
+{
+    for (const auto& token : getBuiltinTokens())
+    {
+        if (token.value("contract").toString().toLower() == normalizedAddress)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void SwapEthSettingsItem::loadCustomTokens()
+{
+    m_customTokens = AppModel::getInstance().getSettings().getEthCustomTokens();
+}
+
+void SwapEthSettingsItem::saveCustomTokens()
+{
+    AppModel::getInstance().getSettings().setEthCustomTokens(m_customTokens);
 }
 
 QStringList SwapEthSettingsItem::getEthereumAddresses() const
@@ -413,15 +544,13 @@ QString SwapEthSettingsItem::getChainName(quint64 chainID)
     }
 }
 
-void SwapEthSettingsItem::onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok)
+void SwapEthSettingsItem::onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok, bool wrongNetwork, const QString& errorMsg)
 {
-    m_endpointCheckOk = ok;   // 'ok' is false for BOTH connection failures and
-                              // wrong-network endpoints (core enforces chain id)
+    m_endpointCheckOk = ok;
     if (!ok)
     {
-        if (chainID != 0)
+        if (wrongNetwork)
         {
-            // core was able to identify the chain even though it's not the required one
             //% "Connected to %1, but Ethereum Mainnet is required"
             m_endpointCheckResult = qtTrId("settings-eth-endpoint-wrong-network").arg(getChainName(chainID));
         }
@@ -429,6 +558,10 @@ void SwapEthSettingsItem::onEndpointValidated(quint64 chainID, quint64 blockNumb
         {
             //% "Unable to connect"
             m_endpointCheckResult = qtTrId("settings-eth-endpoint-failed");
+            if (!errorMsg.isEmpty())
+            {
+                m_endpointCheckResult += " (" + errorMsg + ")";
+            }
         }
     }
     else

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.cpp
@@ -14,8 +14,11 @@
 
 #include "swap_eth_settings_item.h"
 
+#include <QLocale>
+
 #include "mnemonic/mnemonic.h"
 #include "model/app_model.h"
+#include "model/swap_eth_client_model.h"
 #include "viewmodel/qml_globals.h"
 #include "seed_phrase_item.h"
 #include "viewmodel/settings_helpers.h"
@@ -35,6 +38,7 @@ SwapEthSettingsItem::SwapEthSettingsItem()
     auto coinClient = m_coinClient.lock();
     connect(coinClient.get(), SIGNAL(statusChanged()), this, SIGNAL(connectionStatusChanged()));
     connect(coinClient.get(), SIGNAL(connectionErrorChanged()), this, SIGNAL(connectionErrorChanged()));
+    connect(coinClient.get(), &SwapEthClientModel::endpointValidated, this, &SwapEthSettingsItem::onEndpointValidated);
     LoadSettings();
 }
 
@@ -58,8 +62,11 @@ void SwapEthSettingsItem::applySettings()
     m_settings->m_shouldConnect = m_shouldConnect;
     m_settings->m_projectID = m_infuraProjectID.toStdString();
     m_settings->m_secretWords = GetSeedPhraseFromSeedItems();
+    m_settings->m_useCustomRpc = m_useCustomRpc;
+    m_settings->m_customRpcUrl = m_customRpcUrl.trimmed().toStdString();
 
     coinClient->SetSettings(*m_settings);
+    clearEndpointCheck();
 }
 
 void SwapEthSettingsItem::clearSettings()
@@ -107,6 +114,14 @@ void SwapEthSettingsItem::validateCurrentSeedPhrase()
     }
 
     setIsCurrentSeedValid(isValidMnemonic(seedPhrases, language::en));
+}
+
+void SwapEthSettingsItem::validateEndpoint()
+{
+    if (auto c = m_coinClient.lock())
+    {
+        c->validateEndpoint();
+    }
 }
 
 QStringList SwapEthSettingsItem::getEthereumAddresses() const
@@ -206,6 +221,8 @@ void SwapEthSettingsItem::LoadSettings()
     {
         SetSeedPhrase(m_settings->m_secretWords);
         infuraProjectID(str2qstr(m_settings->m_projectID));
+        setUseCustomRpc(m_settings->m_useCustomRpc);
+        setCustomRpcUrl(str2qstr(m_settings->m_customRpcUrl));
 
         setAccountIndex(m_settings->m_accountIndex);
         shouldConnect(m_settings->m_shouldConnect);
@@ -256,6 +273,8 @@ void SwapEthSettingsItem::SetDefaultSettings(bool clearSeed)
 {
     infuraProjectID("");
     setAccountIndex(0);
+    setUseCustomRpc(false);
+    setCustomRpcUrl("");
 
     if (clearSeed)
     {
@@ -274,6 +293,7 @@ void SwapEthSettingsItem::infuraProjectID(const QString& value)
     {
         m_infuraProjectID = value;
         emit infuraProjectIDChanged();
+        clearEndpointCheck();
     }
 }
 
@@ -336,6 +356,97 @@ QString SwapEthSettingsItem::getConnectionError() const
 
     default:
         return QString();
+    }
+}
+
+bool SwapEthSettingsItem::useCustomRpc() const
+{
+    return m_useCustomRpc;
+}
+
+void SwapEthSettingsItem::setUseCustomRpc(bool value)
+{
+    if (value != m_useCustomRpc)
+    {
+        m_useCustomRpc = value;
+        emit useCustomRpcChanged();
+        clearEndpointCheck();
+    }
+}
+
+QString SwapEthSettingsItem::customRpcUrl() const
+{
+    return m_customRpcUrl;
+}
+
+void SwapEthSettingsItem::setCustomRpcUrl(const QString& value)
+{
+    if (value != m_customRpcUrl)
+    {
+        m_customRpcUrl = value;
+        emit customRpcUrlChanged();
+        clearEndpointCheck();
+    }
+}
+
+QString SwapEthSettingsItem::endpointCheckResult() const
+{
+    return m_endpointCheckResult;
+}
+
+bool SwapEthSettingsItem::endpointCheckOk() const
+{
+    return m_endpointCheckOk;
+}
+
+QString SwapEthSettingsItem::getChainName(quint64 chainID)
+{
+    switch (chainID)
+    {
+    //% "Ethereum Mainnet"
+    case 1:  return qtTrId("settings-eth-chain-mainnet");
+    //% "Sepolia Testnet"
+    case 11155111: return qtTrId("settings-eth-chain-sepolia");
+    default:
+        //% "chain %1"
+        return qtTrId("settings-eth-chain-other").arg(chainID);
+    }
+}
+
+void SwapEthSettingsItem::onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok)
+{
+    m_endpointCheckOk = ok;   // 'ok' is false for BOTH connection failures and
+                              // wrong-network endpoints (core enforces chain id)
+    if (!ok)
+    {
+        if (chainID != 0)
+        {
+            // core was able to identify the chain even though it's not the required one
+            //% "Connected to %1, but Ethereum Mainnet is required"
+            m_endpointCheckResult = qtTrId("settings-eth-endpoint-wrong-network").arg(getChainName(chainID));
+        }
+        else
+        {
+            //% "Unable to connect"
+            m_endpointCheckResult = qtTrId("settings-eth-endpoint-failed");
+        }
+    }
+    else
+    {
+        //% "Connected to %1. Latest block: %2"
+        m_endpointCheckResult = qtTrId("settings-eth-endpoint-ok")
+            .arg(getChainName(chainID)).arg(QLocale().toString((qulonglong)blockNumber));
+    }
+    emit endpointCheckResultChanged();
+}
+
+void SwapEthSettingsItem::clearEndpointCheck()
+{
+    if (!m_endpointCheckResult.isEmpty() || m_endpointCheckOk)
+    {
+        m_endpointCheckResult.clear();
+        m_endpointCheckOk = false;
+        emit endpointCheckResultChanged();
     }
 }
 

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
@@ -36,11 +36,15 @@ class SwapEthSettingsItem : public QObject
     Q_PROPERTY(bool            isCurrentSeedValid       READ isCurrentSeedValid                                     NOTIFY isCurrentSeedValidChanged)
     Q_PROPERTY(QString         infuraProjectID          READ infuraProjectID          WRITE infuraProjectID         NOTIFY infuraProjectIDChanged)
     Q_PROPERTY(unsigned int    accountIndex             READ getAccountIndex          WRITE setAccountIndex         NOTIFY accountIndexChanged)
-                                                        
+
     Q_PROPERTY(bool            canChangeConnection      READ canChangeConnection                                    NOTIFY canChangeConnectionChanged)
     Q_PROPERTY(bool            isConnected              READ getIsConnected                                         NOTIFY connectionChanged)
     Q_PROPERTY(QString         connectionStatus         READ getConnectionStatus                                    NOTIFY connectionStatusChanged)
     Q_PROPERTY(QString         connectionError          READ getConnectionError                                     NOTIFY connectionErrorChanged)
+    Q_PROPERTY(bool            useCustomRpc             READ useCustomRpc             WRITE setUseCustomRpc         NOTIFY useCustomRpcChanged)
+    Q_PROPERTY(QString         customRpcUrl             READ customRpcUrl             WRITE setCustomRpcUrl         NOTIFY customRpcUrlChanged)
+    Q_PROPERTY(QString         endpointCheckResult      READ endpointCheckResult                                    NOTIFY endpointCheckResultChanged)
+    Q_PROPERTY(bool            endpointCheckOk          READ endpointCheckOk                                        NOTIFY endpointCheckResultChanged)
 
 
 public:
@@ -56,6 +60,7 @@ public:
     Q_INVOKABLE void copySeedPhrases();
     Q_INVOKABLE void validateCurrentSeedPhrase();
     Q_INVOKABLE QStringList getEthereumAddresses() const;
+    Q_INVOKABLE void validateEndpoint();
 
 private:
     QString getTitle() const;
@@ -83,7 +88,17 @@ private:
     QString getConnectionStatus() const;
     QString getConnectionError() const;
 
+    bool useCustomRpc() const;
+    void setUseCustomRpc(bool value);
+    QString customRpcUrl() const;
+    void setCustomRpcUrl(const QString& value);
+    QString endpointCheckResult() const;
+    bool endpointCheckOk() const;
+    void onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok);
+
     std::vector<std::string> GetSeedPhraseFromSeedItems() const;
+    static QString getChainName(quint64 chainID);
+    void clearEndpointCheck();
 
 signals:
     void infuraProjectIDChanged();
@@ -95,6 +110,9 @@ signals:
     void connectionStatusChanged();
     void connectionErrorChanged();
     void foldedChanged();
+    void useCustomRpcChanged();
+    void customRpcUrlChanged();
+    void endpointCheckResultChanged();
 
 private:
     std::weak_ptr<SwapEthClientModel> m_coinClient;
@@ -105,4 +123,8 @@ private:
     QString m_infuraProjectID;
     unsigned int m_accountIndex;
     bool m_isFolded = true;
+    bool m_useCustomRpc = false;
+    QString m_customRpcUrl;
+    QString m_endpointCheckResult;
+    bool m_endpointCheckOk = false;
 };

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <QObject>
+#include <QMap>
+#include <QVariant>
 #include <memory>
 #include <boost/optional.hpp>
 #include "wallet/transactions/swaps/bridges/ethereum/settings.h"
@@ -46,6 +48,10 @@ class SwapEthSettingsItem : public QObject
     Q_PROPERTY(QString         endpointCheckResult      READ endpointCheckResult                                    NOTIFY endpointCheckResultChanged)
     Q_PROPERTY(bool            endpointCheckOk          READ endpointCheckOk                                        NOTIFY endpointCheckResultChanged)
 
+    Q_PROPERTY(QList<QMap<QString, QVariant>> customTokens READ getCustomTokens                                     NOTIFY customTokensChanged)
+    // fixed DAI/USDT/WBTC contracts the wallet already supports natively, shown as
+    // non-removable rows above the user-added custom tokens
+    Q_PROPERTY(QList<QMap<QString, QVariant>> builtinTokens READ getBuiltinTokens                                   CONSTANT)
 
 public:
     SwapEthSettingsItem();
@@ -61,6 +67,10 @@ public:
     Q_INVOKABLE void validateCurrentSeedPhrase();
     Q_INVOKABLE QStringList getEthereumAddresses() const;
     Q_INVOKABLE void validateEndpoint();
+
+    Q_INVOKABLE void lookupToken(const QString& contractAddress);
+    Q_INVOKABLE void addCustomToken(const QString& contractAddress, const QString& symbol, uint decimals);
+    Q_INVOKABLE void removeCustomToken(const QString& contractAddress);
 
 private:
     QString getTitle() const;
@@ -94,11 +104,18 @@ private:
     void setCustomRpcUrl(const QString& value);
     QString endpointCheckResult() const;
     bool endpointCheckOk() const;
-    void onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok);
+    void onEndpointValidated(quint64 chainID, quint64 blockNumber, bool ok, bool wrongNetwork, const QString& errorMsg);
 
     std::vector<std::string> GetSeedPhraseFromSeedItems() const;
     static QString getChainName(quint64 chainID);
     void clearEndpointCheck();
+
+    QList<QMap<QString, QVariant>> getCustomTokens() const;
+    QList<QMap<QString, QVariant>> getBuiltinTokens() const;
+    bool isBuiltinTokenContract(const QString& normalizedAddress) const;
+    void loadCustomTokens();
+    void saveCustomTokens();
+    void onGotTokenInfo(const QString& contract, const QString& symbol, uint decimals, const QString& error);
 
 signals:
     void infuraProjectIDChanged();
@@ -113,6 +130,8 @@ signals:
     void useCustomRpcChanged();
     void customRpcUrlChanged();
     void endpointCheckResultChanged();
+    void customTokensChanged();
+    void tokenInfoReady(const QString& contract, const QString& symbol, uint decimals, const QString& error);
 
 private:
     std::weak_ptr<SwapEthClientModel> m_coinClient;
@@ -127,4 +146,5 @@ private:
     QString m_customRpcUrl;
     QString m_endpointCheckResult;
     bool m_endpointCheckOk = false;
+    QList<QMap<QString, QVariant>> m_customTokens; // {"contract","symbol","decimals"}, persisted per wallet
 };

--- a/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
+++ b/ui/viewmodel/atomic_swap/swap_eth_settings_item.h
@@ -115,7 +115,6 @@ private:
     bool isBuiltinTokenContract(const QString& normalizedAddress) const;
     void loadCustomTokens();
     void saveCustomTokens();
-    void onGotTokenInfo(const QString& contract, const QString& symbol, uint decimals, const QString& error);
 
 signals:
     void infuraProjectIDChanged();

--- a/ui/viewmodel/atomic_swap/swap_offer_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_offer_item.cpp
@@ -18,18 +18,8 @@
 #include "wallet/transactions/swaps/common.h"
 #include "viewmodel/ui_helpers.h"
 #include "viewmodel/qml_globals.h"
+#include "swap_utils.h"
 #include <algorithm>
-
-namespace
-{
-    // token amounts are quoted in wallet units, min(decimals, 9) fractional
-    // digits (WalletUnitsPerToken rule, wallet/transactions/swaps/common.cpp)
-    uint8_t TokenWalletDecimals(uint8_t onChainDecimals)
-    {
-        return std::min<uint8_t>(onChainDecimals, 9);
-    }
-}
-
 
 SwapOfferItem::SwapOfferItem(QObject* parent /* = nullptr*/)
     : QObject(parent)
@@ -72,16 +62,6 @@ beam::Amount SwapOfferItem::rawAmountReceive() const
     return isSendBeam() ? m_offer.amountSwapCoin() : m_offer.amountBeam(); 
 }
 
-namespace
-{
-    // strips the trailing " UNIT" label AmountToUIString(value, Currencies, true) appends
-    QString StripUnit(const QString& value)
-    {
-        const auto idx = value.indexOf(' ');
-        return idx < 0 ? value : value.left(idx);
-    }
-}
-
 QString SwapOfferItem::rate() const
 {
     beam::Amount otherCoinAmount =
@@ -98,12 +78,12 @@ QString SwapOfferItem::rate() const
     {
         uint8_t onChainDecimals = 0;
         m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
-        otherDecimals = TokenWalletDecimals(onChainDecimals);
+        otherDecimals = beamui::tokenWalletDecimals(onChainDecimals);
         otherAmountStr = beamui::AmountToUIStringExactDecimals(otherCoinAmount, otherDecimals);
     }
     else
     {
-        otherAmountStr = StripUnit(beamui::AmountToUIString(otherCoinAmount, getSwapCoinType(), true));
+        otherAmountStr = beamui::AmountToUIString(otherCoinAmount, getSwapCoinType(), false);
     }
 
     return QMLGlobals::divideWithPrecision(
@@ -139,14 +119,7 @@ QString SwapOfferItem::amountSwapCoinSide(beam::Amount value) const
 {
     if (m_offer.ResolveCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
     {
-        std::string symbol;
-        uint8_t onChainDecimals = 0;
-        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
-        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
-        // exact-decimals variant: TokenWalletDecimals(0) is a valid 0, which the
-        // unitName overload would silently replace with the BEAM default
-        auto amountStr = beamui::AmountToUIStringExactDecimals(value, TokenWalletDecimals(onChainDecimals));
-        return symbol.empty() ? amountStr : amountStr + " " + QString::fromStdString(symbol);
+        return swapui::erc20AmountString(m_offer, value, true);
     }
     return beamui::AmountToUIString(value, getSwapCoinType());
 }
@@ -180,9 +153,7 @@ QString SwapOfferItem::getSwapCoinName() const
 {
     if (m_offer.ResolveCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
     {
-        std::string symbol;
-        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
-        return symbol.empty() ? QString("ERC20") : QString::fromStdString(symbol);
+        return swapui::erc20Symbol(m_offer);
     }
     return toString(getSwapCoinType());
 }

--- a/ui/viewmodel/atomic_swap/swap_offer_item.cpp
+++ b/ui/viewmodel/atomic_swap/swap_offer_item.cpp
@@ -15,8 +15,20 @@
 #include "swap_offer_item.h"
 #include "utility/helpers.h"
 #include "wallet/core/common.h"
+#include "wallet/transactions/swaps/common.h"
 #include "viewmodel/ui_helpers.h"
 #include "viewmodel/qml_globals.h"
+#include <algorithm>
+
+namespace
+{
+    // token amounts are quoted in wallet units, min(decimals, 9) fractional
+    // digits (WalletUnitsPerToken rule, wallet/transactions/swaps/common.cpp)
+    uint8_t TokenWalletDecimals(uint8_t onChainDecimals)
+    {
+        return std::min<uint8_t>(onChainDecimals, 9);
+    }
+}
 
 
 SwapOfferItem::SwapOfferItem(QObject* parent /* = nullptr*/)
@@ -60,6 +72,16 @@ beam::Amount SwapOfferItem::rawAmountReceive() const
     return isSendBeam() ? m_offer.amountSwapCoin() : m_offer.amountBeam(); 
 }
 
+namespace
+{
+    // strips the trailing " UNIT" label AmountToUIString(value, Currencies, true) appends
+    QString StripUnit(const QString& value)
+    {
+        const auto idx = value.indexOf(' ');
+        return idx < 0 ? value : value.left(idx);
+    }
+}
+
 QString SwapOfferItem::rate() const
 {
     beam::Amount otherCoinAmount =
@@ -69,22 +91,64 @@ QString SwapOfferItem::rate() const
 
     if (!beamAmount) return QString();
 
+    QString otherAmountStr;
+    uint8_t otherDecimals = beamui::getCurrencyDecimals(getSwapCoinType());
+
+    if (m_offer.ResolveCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        uint8_t onChainDecimals = 0;
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
+        otherDecimals = TokenWalletDecimals(onChainDecimals);
+        otherAmountStr = beamui::AmountToUIStringExactDecimals(otherCoinAmount, otherDecimals);
+    }
+    else
+    {
+        otherAmountStr = StripUnit(beamui::AmountToUIString(otherCoinAmount, getSwapCoinType(), true));
+    }
+
     return QMLGlobals::divideWithPrecision(
-        beamui::AmountToUIString(otherCoinAmount, getSwapCoinType(), false),
-        beamui::AmountToUIString(beamAmount), 
-        beamui::getCurrencyDecimals(getSwapCoinType()));
+        otherAmountStr,
+        beamui::AmountToUIString(beamAmount),
+        otherDecimals);
 }
 
 QString SwapOfferItem::amountSend() const
 {
-    auto coinType = isSendBeam() ? beamui::Currencies::Beam : getSwapCoinType();
-    return beamui::AmountToUIString(rawAmountSend(), coinType);
+    return isSendBeam() ? amountBeamSide(rawAmountSend()) : amountSwapCoinSide(rawAmountSend());
 }
 
 QString SwapOfferItem::amountReceive() const
 {
-    auto coinType = isSendBeam() ? getSwapCoinType() : beamui::Currencies::Beam;
-    return beamui::AmountToUIString(rawAmountReceive(), coinType);
+    return isSendBeam() ? amountSwapCoinSide(rawAmountReceive()) : amountBeamSide(rawAmountReceive());
+}
+
+QString SwapOfferItem::amountBeamSide(beam::Amount value) const
+{
+    beam::Asset::ID assetId = 0;
+    m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetID, assetId);
+    if (assetId != 0)
+    {
+        std::string assetName;
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetName, assetName);
+        return beamui::AmountToUIString(value, QString::fromStdString(assetName));
+    }
+    return beamui::AmountToUIString(value, beamui::Currencies::Beam);
+}
+
+QString SwapOfferItem::amountSwapCoinSide(beam::Amount value) const
+{
+    if (m_offer.ResolveCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        std::string symbol;
+        uint8_t onChainDecimals = 0;
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
+        // exact-decimals variant: TokenWalletDecimals(0) is a valid 0, which the
+        // unitName overload would silently replace with the BEAM default
+        auto amountStr = beamui::AmountToUIStringExactDecimals(value, TokenWalletDecimals(onChainDecimals));
+        return symbol.empty() ? amountStr : amountStr + " " + QString::fromStdString(symbol);
+    }
+    return beamui::AmountToUIString(value, getSwapCoinType());
 }
 
 bool SwapOfferItem::isOwnOffer() const
@@ -114,7 +178,31 @@ beamui::Currencies SwapOfferItem::getSwapCoinType() const
 
 QString SwapOfferItem::getSwapCoinName() const
 {
+    if (m_offer.ResolveCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        std::string symbol;
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        return symbol.empty() ? QString("ERC20") : QString::fromStdString(symbol);
+    }
     return toString(getSwapCoinType());
+}
+
+beam::wallet::AtomicSwapCoin SwapOfferItem::resolvedSwapCoin() const
+{
+    return m_offer.ResolveCoin();
+}
+
+QString SwapOfferItem::getBeamSideName() const
+{
+    beam::Asset::ID assetId = 0;
+    m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetID, assetId);
+    if (assetId != 0)
+    {
+        std::string assetName;
+        m_offer.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetName, assetName);
+        return assetName.empty() ? QString("beam") : QString::fromStdString(assetName);
+    }
+    return "beam";
 }
 
 void SwapOfferItem::reset(const beam::wallet::SwapOffer& offer)

--- a/ui/viewmodel/atomic_swap/swap_offer_item.h
+++ b/ui/viewmodel/atomic_swap/swap_offer_item.h
@@ -42,6 +42,8 @@ public:
     beam::wallet::TxParameters getTxParameters() const;
     beam::wallet::TxID getTxID() const;
     QString getSwapCoinName() const;
+    QString getBeamSideName() const; // "beam", or the CA's unit name for extended offers
+    beam::wallet::AtomicSwapCoin resolvedSwapCoin() const; // SwapOffer::ResolveCoin()
 protected:
     void reset(const beam::wallet::SwapOffer& offer);
 
@@ -49,6 +51,8 @@ signals:
 
 private:
     beamui::Currencies getSwapCoinType() const;
+    QString amountBeamSide(beam::Amount value) const;
+    QString amountSwapCoinSide(beam::Amount value) const;
 
     beam::wallet::SwapOffer m_offer;          /// TxParameters subclass
     bool m_isBeamSide;                        /// pay beam to receive other coin

--- a/ui/viewmodel/atomic_swap/swap_offers_list.cpp
+++ b/ui/viewmodel/atomic_swap/swap_offers_list.cpp
@@ -97,7 +97,7 @@ QVariant SwapOffersList::data(const QModelIndex &index, int role) const
         case Roles::Pair:
         {
             auto swapCoin = value->getSwapCoinName();
-            const QString beam = "beam";
+            auto beam = value->getBeamSideName();
             return  value->isSendBeam() ? beam + '-' + swapCoin : swapCoin + '-' + beam;
         }
         default:

--- a/ui/viewmodel/atomic_swap/swap_offers_view.cpp
+++ b/ui/viewmodel/atomic_swap/swap_offers_view.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <qdebug.h>
+#include <algorithm>
+#include <QRegularExpression>
 #include "model/app_model.h"
 #include "model/settings.h"
+#include "model/assets_manager.h"
 #include "swap_offers_view.h"
 #include "viewmodel/ui_helpers.h"
 #include "viewmodel/qml_globals.h"
@@ -211,6 +214,16 @@ SwapOffersViewModel::SwapOffersViewModel()
             SLOT(onSwapOffersDataModelChanged(beam::wallet::ChangeAction, const std::vector<beam::wallet::SwapOffer>&)));
 
     monitorAllOffersFitBalance();
+
+    connect(AppModel::getInstance().getAssets().get(), &AssetsManager::assetsListChanged, this, &SwapOffersViewModel::coinFilterListChanged);
+    connect(&AppModel::getInstance().getSettings(), &WalletSettings::ethCustomTokensChanged, this, &SwapOffersViewModel::coinFilterListChanged);
+    connect(&AppModel::getInstance().getSettings(), &WalletSettings::ethCustomTokensChanged, this, &SwapOffersViewModel::customTokenCardsChanged);
+
+    {
+        auto ethClient = AppModel::getInstance().getSwapEthClient();
+        connect(ethClient.get(), SIGNAL(tokenBalancesChanged()), this, SIGNAL(customTokenCardsChanged()));
+        connect(ethClient.get(), SIGNAL(statusChanged()), this, SIGNAL(customTokenCardsChanged()));
+    }
 
     m_walletModel->getAsync()->getSwapOffers();
     m_walletModel->getAsync()->getTransactions();
@@ -512,13 +525,43 @@ bool SwapOffersViewModel::isOfferFitBalance(const SwapOfferItem& offer)
     bool isSendBeam = offer.isSendBeam();
     beam::AmountBig::Number beamOfferAmount = isSendBeam ? offer.rawAmountSend() : offer.rawAmountReceive();
 
-    if (isSendBeam && beamOfferAmount > m_walletModel->getAvailable(beam::Asset::s_BeamID))
-        return false;
-    
+    if (isSendBeam)
+    {
+        // when the user would send a Confidential Asset, check that asset's
+        // balance rather than plain BEAM (0 == plain BEAM, getAvailable(0)
+        // is the BEAM balance, so this covers both cases)
+        beam::Asset::ID beamAssetId = 0;
+        offer.getTxParameters().GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetID, beamAssetId);
+        if (beamOfferAmount > m_walletModel->getAvailable(beamAssetId))
+            return false;
+    }
+
     auto swapCoinOfferAmount = isSendBeam ? offer.rawAmountReceive() : offer.rawAmountSend();
-    // TODO: find better solution to get AtomicSwapCoin
-    auto swapCoin = offer.getTxParameters().GetParameter<beam::wallet::AtomicSwapCoin>(beam::wallet::TxParameterID::AtomicSwapCoin);
-    auto swapCoinClientWrapper = getSwapCoinClientWrapper(*swapCoin);
+    auto swapCoin = offer.resolvedSwapCoin();
+
+    if (swapCoin == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        if (isSendBeam)
+            return true; // sending BEAM/asset, receiving the token: no lock-side balance to check
+
+        // no live per-token balance tracking here (out of scope for the list
+        // filter); an offer "fits" only if the user has already added the
+        // contract in the ethereum settings
+        std::string contract;
+        offer.getTxParameters().GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenContract, contract);
+        // contract addresses are hex and commonly EIP-55 mixed-case; compare
+        // case-insensitively
+        const auto offerContract = QString::fromStdString(contract);
+        const auto storedTokens = AppModel::getInstance().getSettings().getEthCustomTokens();
+        for (const auto& token : storedTokens)
+        {
+            if (token.value("contract").toString().compare(offerContract, Qt::CaseInsensitive) == 0)
+                return true;
+        }
+        return false;
+    }
+
+    auto swapCoinClientWrapper = getSwapCoinClientWrapper(swapCoin);
 
     if (swapCoinClientWrapper->getIsConnected())
     {
@@ -614,6 +657,97 @@ void SwapOffersViewModel::InitSwapClientWrappers()
 QQmlListProperty<SwapCoinClientWrapper> SwapOffersViewModel::getSwapClients()
 {
     return beamui::CreateQmlListProperty<SwapCoinClientWrapper>(this, m_swapClientWrappers);
+}
+
+namespace
+{
+    QMap<QString, QVariant> MakeCoinFilterEntry(const QString& text, const QString& pairName)
+    {
+        // matches the classic-pair separator convention (atomic_swap.qml):
+        // one side of "pair" equals this name, delimited by '-'
+        auto escaped = QRegularExpression::escape(pairName);
+        QMap<QString, QVariant> entry;
+        entry.insert("text", text);
+        entry.insert("pair", "^(" + escaped + "-)|(-" + escaped + ")$");
+        return entry;
+    }
+}
+
+QList<QMap<QString, QVariant>> SwapOffersViewModel::getCoinFilterList() const
+{
+    QList<QMap<QString, QVariant>> result;
+
+    QMap<QString, QVariant> allEntry;
+    //% "(all)"
+    allEntry.insert("text", qtTrId("atomic-swap-all-coins"));
+    allEntry.insert("pair", "");
+    result.push_back(allEntry);
+
+    static const char* classicCoins[] = { "BTC", "DAI", "DASH", "DOGE", "ETH", "LTC", "QTUM", "USDT", "WBTC" };
+    for (const auto* coin : classicCoins)
+    {
+        result.push_back(MakeCoinFilterEntry(coin, coin));
+    }
+
+    for (const auto& token : AppModel::getInstance().getSettings().getEthCustomTokens())
+    {
+        auto symbol = token.value("symbol").toString();
+        if (!symbol.isEmpty())
+        {
+            result.push_back(MakeCoinFilterEntry(symbol, symbol));
+        }
+    }
+
+    for (const auto& asset : AppModel::getInstance().getAssets()->getAssetsList())
+    {
+        auto assetId = asset.value("assetId").toUInt();
+        if (assetId == 0)
+        {
+            continue; // plain BEAM is covered by the classic pairs already
+        }
+        auto unitName = asset.value("unitName").toString();
+        if (!unitName.isEmpty())
+        {
+            result.push_back(MakeCoinFilterEntry(unitName, unitName));
+        }
+    }
+
+    return result;
+}
+
+QList<QMap<QString, QVariant>> SwapOffersViewModel::getCustomTokenCards() const
+{
+    QList<QMap<QString, QVariant>> result;
+
+    auto ethClient = AppModel::getInstance().getSwapEthClient();
+    if (!ethClient || ethClient->GetSettings().IsActivated() == false)
+    {
+        return result; // match the DAI/USDT/WBTC cards' visibility rule: eth client must be connected
+    }
+
+    for (const auto& token : AppModel::getInstance().getSettings().getEthCustomTokens())
+    {
+        const auto contract = token.value("contract").toString();
+        const auto symbol = token.value("symbol").toString();
+        const auto decimals = static_cast<uint8_t>(token.value("decimals").toUInt());
+        if (contract.isEmpty() || symbol.isEmpty())
+        {
+            continue;
+        }
+
+        const auto walletDecimals = std::min<uint8_t>(decimals, 9);
+        const auto balance = ethClient->getTokenBalance(contract);
+
+        QMap<QString, QVariant> card;
+        card.insert("contract", contract);
+        card.insert("symbol", symbol);
+        card.insert("available", beamui::AmountToUIStringExactDecimals(balance, walletDecimals));
+        card.insert("color", beamui::ColorFromString(contract));
+        card.insert("isConnected", ethClient->getStatus() == beam::ethereum::Client::Status::Connected);
+        result.push_back(card);
+    }
+
+    return result;
 }
 
 SwapCoinClientWrapper* SwapOffersViewModel::getSwapCoinClientWrapper(beam::wallet::AtomicSwapCoin swapCoinType) const

--- a/ui/viewmodel/atomic_swap/swap_offers_view.cpp
+++ b/ui/viewmodel/atomic_swap/swap_offers_view.cpp
@@ -735,7 +735,7 @@ QList<QMap<QString, QVariant>> SwapOffersViewModel::getCustomTokenCards() const
             continue;
         }
 
-        const auto walletDecimals = std::min<uint8_t>(decimals, 9);
+        const auto walletDecimals = beamui::tokenWalletDecimals(decimals);
         const auto balance = ethClient->getTokenBalance(contract);
 
         QMap<QString, QVariant> card;

--- a/ui/viewmodel/atomic_swap/swap_offers_view.h
+++ b/ui/viewmodel/atomic_swap/swap_offers_view.h
@@ -83,6 +83,13 @@ class SwapOffersViewModel : public QObject
     Q_PROPERTY(bool                                      isOffersLoaded      READ isOffersLoaded         NOTIFY offersLoaded)
     Q_PROPERTY(int                                       activeTxCount       READ getActiveTxCount       NOTIFY allTransactionsChanged)
     Q_PROPERTY(QQmlListProperty<SwapCoinClientWrapper>   swapClientList      READ getSwapClients         CONSTANT)
+    // {"text","pair"} entries for the currency filter combo: the fixed classic
+    // coins plus one entry per stored custom ERC-20 token and (if the wallet
+    // holds any) per Confidential Asset
+    Q_PROPERTY(QList<QMap<QString, QVariant>>            coinFilterList      READ getCoinFilterList      NOTIFY coinFilterListChanged)
+    // one card per stored custom ERC-20 token, live balance from the eth client;
+    // {"contract","symbol","available","color"} -- only meaningful while the eth client is connected
+    Q_PROPERTY(QList<QMap<QString, QVariant>>            customTokenCards    READ getCustomTokenCards    NOTIFY customTokenCardsChanged)
 
 public:
     SwapOffersViewModel();
@@ -96,6 +103,8 @@ public:
     bool isOffersLoaded() const;
     int getActiveTxCount() const;
     QQmlListProperty<SwapCoinClientWrapper> getSwapClients();
+    QList<QMap<QString, QVariant>> getCoinFilterList() const;
+    QList<QMap<QString, QVariant>> getCustomTokenCards() const;
 
     Q_INVOKABLE void cancelOffer(const QVariant& variantTxID);
     Q_INVOKABLE void cancelTx(const QVariant& variantTxID);
@@ -118,6 +127,8 @@ signals:
     void beamAvailableChanged();
     void offerRemovedFromTable(QVariant variantTxID);
     void offersLoaded();
+    void coinFilterListChanged();
+    void customTokenCardsChanged();
 
 private:
     void monitorAllOffersFitBalance();

--- a/ui/viewmodel/atomic_swap/swap_tx_object.cpp
+++ b/ui/viewmodel/atomic_swap/swap_tx_object.cpp
@@ -20,12 +20,20 @@
 #include "model/app_model.h"
 #include "viewmodel/fee_helpers.h"
 #include "viewmodel/ui_helpers.h"
+#include <algorithm>
 
 using namespace beam;
 
 namespace
 {
     constexpr uint32_t kSecondsPerHour = 60 * 60;
+
+    // token amounts are quoted in wallet units, min(decimals, 9) fractional
+    // digits (WalletUnitsPerToken rule, wallet/transactions/swaps/common.cpp)
+    uint8_t TokenWalletDecimals(uint8_t onChainDecimals)
+    {
+        return std::min<uint8_t>(onChainDecimals, 9);
+    }
 
     QString getWaitingPeerStr(const beam::wallet::SwapTxDescription& tx, Height currentHeight)
     {
@@ -192,6 +200,12 @@ bool SwapTxObject::isDeleteAvailable() const
 
 auto SwapTxObject::getSwapCoinName() const -> QString
 {
+    if (m_swapTx.getSwapCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        std::string symbol;
+        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        return symbol.empty() ? QString("ERC20") : QString::fromStdString(symbol);
+    }
     return toString(beamui::convertSwapCoinToCurrency(m_swapTx.getSwapCoin()));
 }
 
@@ -206,12 +220,47 @@ QString SwapTxObject::getSentAmountWithCurrency() const
 
 QString SwapTxObject::getAmountWithCurrency() const
 {
+    beam::Asset::ID assetId = 0;
+    _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetID, assetId);
+    if (assetId != 0)
+    {
+        std::string assetName;
+        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetName, assetName);
+        return beamui::AmountToUIString(_tx.m_amount, QString::fromStdString(assetName));
+    }
     return AmountToUIString(_tx.m_amount, beamui::Currencies::Beam);
+}
+
+QString SwapTxObject::getSwapCoinAmountString(beam::Amount value, bool withCurrency) const
+{
+    if (m_swapTx.getSwapCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
+    {
+        uint8_t onChainDecimals = 0;
+        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
+        auto amountStr = beamui::AmountToUIStringExactDecimals(value, TokenWalletDecimals(onChainDecimals));
+        if (!withCurrency)
+        {
+            return amountStr;
+        }
+        std::string symbol;
+        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        return symbol.empty() ? amountStr : amountStr + " " + QString::fromStdString(symbol);
+    }
+    return withCurrency ? AmountToUIString(value, beamui::convertSwapCoinToCurrency(m_swapTx.getSwapCoin()))
+                         : beamui::AmountToUIString(value);
 }
 
 QString SwapTxObject::getSentAmount() const
 {
-    QString amount = beamui::AmountToUIString(getSentAmountValue());
+    QString amount;
+    if (_tx.m_txType == beam::wallet::TxType::AtomicSwap && !m_swapTx.isBeamSide())
+    {
+        amount = getSwapCoinAmountString(getSentAmountValue(), false);
+    }
+    else
+    {
+        amount = beamui::AmountToUIString(getSentAmountValue());
+    }
     return amount == "0" ? "" : amount;
 }
 
@@ -236,7 +285,15 @@ QString SwapTxObject::getReceivedAmountWithCurrency() const
 
 QString SwapTxObject::getReceivedAmount() const
 {
-    QString amount = beamui::AmountToUIString(getReceivedAmountValue());
+    QString amount;
+    if (_tx.m_txType == beam::wallet::TxType::AtomicSwap && m_swapTx.isBeamSide())
+    {
+        amount = getSwapCoinAmountString(getReceivedAmountValue(), false);
+    }
+    else
+    {
+        amount = beamui::AmountToUIString(getReceivedAmountValue());
+    }
     return amount == "0" ? "" : amount;
 }
 
@@ -255,7 +312,7 @@ QString SwapTxObject::getSwapAmountWithCurrency(bool sent) const
     bool s = sent ? !isBeamSide : isBeamSide;
     if (s)
     {
-        return AmountToUIString(m_swapTx.getSwapAmount(), beamui::convertSwapCoinToCurrency(m_swapTx.getSwapCoin()));
+        return getSwapCoinAmountString(m_swapTx.getSwapAmount(), true);
     }
     return getAmountWithCurrency();
 }

--- a/ui/viewmodel/atomic_swap/swap_tx_object.cpp
+++ b/ui/viewmodel/atomic_swap/swap_tx_object.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "swap_tx_object.h"
+#include "swap_utils.h"
 #include "wallet/transactions/swaps/common.h"
 #include "wallet/transactions/swaps/swap_transaction.h"
 #include "core/ecc.h"
@@ -27,13 +28,6 @@ using namespace beam;
 namespace
 {
     constexpr uint32_t kSecondsPerHour = 60 * 60;
-
-    // token amounts are quoted in wallet units, min(decimals, 9) fractional
-    // digits (WalletUnitsPerToken rule, wallet/transactions/swaps/common.cpp)
-    uint8_t TokenWalletDecimals(uint8_t onChainDecimals)
-    {
-        return std::min<uint8_t>(onChainDecimals, 9);
-    }
 
     QString getWaitingPeerStr(const beam::wallet::SwapTxDescription& tx, Height currentHeight)
     {
@@ -202,9 +196,7 @@ auto SwapTxObject::getSwapCoinName() const -> QString
 {
     if (m_swapTx.getSwapCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
     {
-        std::string symbol;
-        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
-        return symbol.empty() ? QString("ERC20") : QString::fromStdString(symbol);
+        return swapui::erc20Symbol(_tx);
     }
     return toString(beamui::convertSwapCoinToCurrency(m_swapTx.getSwapCoin()));
 }
@@ -235,16 +227,7 @@ QString SwapTxObject::getSwapCoinAmountString(beam::Amount value, bool withCurre
 {
     if (m_swapTx.getSwapCoin() == beam::wallet::AtomicSwapCoin::Erc20Token)
     {
-        uint8_t onChainDecimals = 0;
-        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
-        auto amountStr = beamui::AmountToUIStringExactDecimals(value, TokenWalletDecimals(onChainDecimals));
-        if (!withCurrency)
-        {
-            return amountStr;
-        }
-        std::string symbol;
-        _tx.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
-        return symbol.empty() ? amountStr : amountStr + " " + QString::fromStdString(symbol);
+        return swapui::erc20AmountString(_tx, value, withCurrency);
     }
     return withCurrency ? AmountToUIString(value, beamui::convertSwapCoinToCurrency(m_swapTx.getSwapCoin()))
                          : beamui::AmountToUIString(value);

--- a/ui/viewmodel/atomic_swap/swap_tx_object.cpp
+++ b/ui/viewmodel/atomic_swap/swap_tx_object.cpp
@@ -67,6 +67,23 @@ namespace
         return "";
     }
 
+    QString getCoinsUnlockNoteStr(const beam::wallet::SwapTxDescription& tx, Height currentHeight)
+    {
+        if (tx.isRedeemTxRegistered())
+        {
+            return "";
+        }
+
+        auto minHeightRefund = tx.getMinRefundTxHeight();
+        if (minHeightRefund && currentHeight < *minHeightRefund)
+        {
+            QString time = beamui::convertBeamHeightDiffToTime(*minHeightRefund - currentHeight);
+            //% "While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most."
+            return qtTrId("swap-details-unlock-note").arg(time);
+        }
+        return "";
+    }
+
     QString getInProgressRefundingStr(const beam::wallet::SwapTxDescription& tx, double blocksPerHour, Height currentBeamHeight)
     {
         
@@ -335,6 +352,42 @@ QString SwapTxObject::getStateDetails() const
             else
             {
                 return getWaitingPeerStr(m_swapTx, currentHeight);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return "";
+}
+
+QString SwapTxObject::getCoinsUnlockNote() const
+{
+    if (getTxDescription().m_txType == beam::wallet::TxType::AtomicSwap)
+    {
+        switch (getTxDescription().m_status)
+        {
+        case beam::wallet::TxStatus::Pending:
+        case beam::wallet::TxStatus::InProgress:
+        {
+            Height currentHeight = AppModel::getInstance().getWalletModel()->getCurrentHeight();
+            auto state = m_swapTx.getState();
+            if (state)
+            {
+                switch (*state)
+                {
+                case wallet::AtomicSwapTransaction::State::BuildingBeamLockTX:
+                case wallet::AtomicSwapTransaction::State::BuildingBeamRefundTX:
+                case wallet::AtomicSwapTransaction::State::BuildingBeamRedeemTX:
+                case wallet::AtomicSwapTransaction::State::HandlingContractTX:
+                case wallet::AtomicSwapTransaction::State::SendingBeamLockTX:
+                case wallet::AtomicSwapTransaction::State::SendingRedeemTX:
+                case wallet::AtomicSwapTransaction::State::SendingBeamRedeemTX:
+                    return getCoinsUnlockNoteStr(m_swapTx, currentHeight);
+                default:
+                    break;
+                }
             }
             break;
         }

--- a/ui/viewmodel/atomic_swap/swap_tx_object.h
+++ b/ui/viewmodel/atomic_swap/swap_tx_object.h
@@ -48,6 +48,7 @@ public:
     auto getFee() const -> QString override;
     auto getFailureReason() const -> QString override;
     QString getStateDetails() const override;
+    QString getCoinsUnlockNote() const;
     beam::wallet::AtomicSwapCoin getSwapCoinType() const;
     auto getStatus() const -> QString override;
     QString getAmountWithCurrency() const;

--- a/ui/viewmodel/atomic_swap/swap_tx_object.h
+++ b/ui/viewmodel/atomic_swap/swap_tx_object.h
@@ -71,6 +71,7 @@ signals:
 private:
     auto getSwapAmountValue(bool sent) const -> beam::Amount;
     auto getSwapAmountWithCurrency(bool sent) const -> QString;
+    QString getSwapCoinAmountString(beam::Amount value, bool withCurrency) const;
 
     beam::wallet::SwapTxDescription m_swapTx;
     uint32_t m_lockTxMinConfirmations = 0;

--- a/ui/viewmodel/atomic_swap/swap_tx_object_list.cpp
+++ b/ui/viewmodel/atomic_swap/swap_tx_object_list.cpp
@@ -72,7 +72,8 @@ auto SwapTxObjectList::roleNames() const -> QHash<int, QByteArray>
         { static_cast<int>(Roles::BeamLockTxKernelId), "beamLockTxKernelId" },
         { static_cast<int>(Roles::BeamRedeemTxKernelId), "beamRedeemTxKernelId" },
         { static_cast<int>(Roles::BeamRefundTxKernelId), "beamRefundTxKernelId" },
-        { static_cast<int>(Roles::StateDetails), "stateDetails" }
+        { static_cast<int>(Roles::StateDetails), "stateDetails" },
+        { static_cast<int>(Roles::CoinsUnlockNote), "coinsUnlockNote" }
     };
     return roles;
 }
@@ -240,6 +241,9 @@ auto SwapTxObjectList::data(const QModelIndex &index, int role) const -> QVarian
 
         case Roles::StateDetails:
             return value->getStateDetails();
+
+        case Roles::CoinsUnlockNote:
+            return value->getCoinsUnlockNote();
 
         default:
             return QVariant();

--- a/ui/viewmodel/atomic_swap/swap_tx_object_list.h
+++ b/ui/viewmodel/atomic_swap/swap_tx_object_list.h
@@ -75,7 +75,8 @@ public:
         BeamLockTxKernelId,
         BeamRedeemTxKernelId,
         BeamRefundTxKernelId,
-        StateDetails
+        StateDetails,
+        CoinsUnlockNote
     };
 
     Q_ENUM(Roles)

--- a/ui/viewmodel/atomic_swap/swap_utils.cpp
+++ b/ui/viewmodel/atomic_swap/swap_utils.cpp
@@ -13,6 +13,9 @@
 // limitations under the License.
 #include "swap_utils.h"
 #include "viewmodel/qml_globals.h"
+#include "viewmodel/ui_helpers.h"
+#include "model/app_model.h"
+#include "wallet/transactions/swaps/bridges/ethereum/common.h"
 
 namespace swapui
 {
@@ -61,5 +64,68 @@ namespace swapui
         append(OldWalletCurrency::OldCurrency::CurrWrappedBTC, "qrc:/assets/icon-wbtc.svg");
 
         return result;
+    }
+
+    QString erc20Symbol(const beam::wallet::TxParameters& params)
+    {
+        std::string symbol;
+        params.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        return symbol.empty() ? QString("ERC20") : QString::fromStdString(symbol);
+    }
+
+    QString erc20AmountString(const beam::wallet::TxParameters& params, beam::Amount value, bool withSymbol)
+    {
+        uint8_t onChainDecimals = 0;
+        params.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals, onChainDecimals);
+        // exact-decimals variant: tokenWalletDecimals(0) is a valid 0, which the
+        // unitName overload would silently replace with the BEAM default
+        auto amountStr = beamui::AmountToUIStringExactDecimals(value, beamui::tokenWalletDecimals(onChainDecimals));
+        if (!withSymbol)
+        {
+            return amountStr;
+        }
+        std::string symbol;
+        params.GetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol, symbol);
+        return symbol.empty() ? amountStr : amountStr + " " + QString::fromStdString(symbol);
+    }
+
+    bool isTokenSide(OldWalletCurrency::OldCurrency currency, const QString& tokenContract)
+    {
+        return currency == OldWalletCurrency::OldCurrency::CurrEthereum && !tokenContract.isEmpty();
+    }
+
+    uint8_t effectiveSwapDecimals(OldWalletCurrency::OldCurrency currency, const QString& tokenContract, uint32_t tokenDecimals)
+    {
+        if (isTokenSide(currency, tokenContract))
+        {
+            return beamui::tokenWalletDecimals(tokenDecimals);
+        }
+        return beamui::getCurrencyDecimals(convertCurrency(currency));
+    }
+
+    void connectFeeRateClients(QObject* receiver, const std::function<void()>& onChanged)
+    {
+        if (auto ethClient = AppModel::getInstance().getSwapEthClient(); ethClient)
+        {
+            QObject::connect(ethClient.get(), &SwapEthClientModel::estimatedFeeRateChanged, receiver, onChanged);
+        }
+        for (auto coin : {beam::wallet::AtomicSwapCoin::Bitcoin, beam::wallet::AtomicSwapCoin::Litecoin,
+                          beam::wallet::AtomicSwapCoin::Qtum, beam::wallet::AtomicSwapCoin::Dogecoin,
+                          beam::wallet::AtomicSwapCoin::Dash, beam::wallet::AtomicSwapCoin::Bitcoin_Cash})
+        {
+            if (auto client = AppModel::getInstance().getSwapCoinClient(coin); client)
+            {
+                QObject::connect(client.get(), &SwapCoinClientModel::estimatedFeeRateChanged, receiver, onChanged);
+            }
+        }
+    }
+
+    bool enoughEthForTokenLock(beam::Amount feeRate)
+    {
+        // no live balance for arbitrary custom tokens: only check the ETH
+        // that pays the lock gas (incl. the approve calls, kApproveTxGasLimit)
+        const beam::Amount lockFee = feeRate *
+            (beam::ethereum::kLockTxGasLimit + 2 * beam::ethereum::kApproveTxGasLimit);
+        return AppModel::getInstance().getSwapEthClient()->getAvailable(beam::wallet::AtomicSwapCoin::Ethereum) >= lockFee;
     }
 }

--- a/ui/viewmodel/atomic_swap/swap_utils.h
+++ b/ui/viewmodel/atomic_swap/swap_utils.h
@@ -14,10 +14,25 @@
 #pragma once
 
 #include <QString>
+#include <functional>
 #include "viewmodel/currencies.h"
+#include "wallet/core/common.h"
 
 namespace swapui
 {
     QString getSwapFeeTitle(OldWalletCurrency::OldCurrency currency);
     QList<QMap<QString, QVariant>> getUICurrList();
+
+    // ERC-20 symbol from the offer/tx parameters, "ERC20" when absent
+    QString erc20Symbol(const beam::wallet::TxParameters& params);
+    // token amount in wallet units, optionally suffixed with the symbol
+    QString erc20AmountString(const beam::wallet::TxParameters& params, beam::Amount value, bool withSymbol);
+    // true when @currency is the pair side a custom ERC-20 token rides on
+    bool isTokenSide(OldWalletCurrency::OldCurrency currency, const QString& tokenContract);
+    // token side -> tokenWalletDecimals, otherwise the classic per-currency table
+    uint8_t effectiveSwapDecimals(OldWalletCurrency::OldCurrency currency, const QString& tokenContract, uint32_t tokenDecimals);
+    // connect every swap-coin client's estimatedFeeRateChanged to @onChanged
+    void connectFeeRateClients(QObject* receiver, const std::function<void()>& onChanged);
+    // the ETH balance covers a token lock's gas (incl. the approve calls) at @feeRate
+    bool enoughEthForTokenLock(beam::Amount feeRate);
 }

--- a/ui/viewmodel/fee_helpers.cpp
+++ b/ui/viewmodel/fee_helpers.cpp
@@ -25,6 +25,7 @@
 #include "wallet/transactions/swaps/bridges/dogecoin/dogecoin_side.h"
 #include "wallet/transactions/swaps/bridges/ethereum/ethereum_side.h"
 #include "wallet/transactions/swaps/utils.h"
+#include "ui_helpers.h"
 
 beam::Amount minFeeBeam(bool isShielded)
 {
@@ -148,7 +149,8 @@ QString calcWithdrawTxFee(OldWalletCurrency::OldCurrency currency, beam::Amount 
     case OldWalletCurrency::OldCurrency::CurrWrappedBTC: {
         auto swapCoin = convertCurrencyToSwapCoin(currency);
         auto total = beam::wallet::EthereumSide::CalcWithdrawTxFee(feeRate, swapCoin);
-        return QString::fromStdString(std::to_string(total)) + " gwei";
+        // the withdraw tx fee is paid in ETH, also for token withdrawals
+        return beamui::AmountToUIString(total, beamui::Currencies::Ethereum);
     }
     default: {
         return QString();

--- a/ui/viewmodel/qml_globals.cpp
+++ b/ui/viewmodel/qml_globals.cpp
@@ -265,7 +265,8 @@ bool QMLGlobals::haveSwapClient(OldWalletCurrency::OldCurrency currency)
     {
         return AppModel::getInstance().getSwapEthClient()->GetSettings().IsActivated();
     }
-    return AppModel::getInstance().getSwapCoinClient(swapCoin)->GetSettings().IsActivated();
+    auto client = AppModel::getInstance().getSwapCoinClient(swapCoin);
+    return client && client->GetSettings().IsActivated();
 }
 
 QString QMLGlobals::rawTxParametrsToTokenStr(const QVariant& variantTxParams)
@@ -292,7 +293,7 @@ bool QMLGlobals::canReceive(OldWalletCurrency::OldCurrency currency)
         return client->GetSettings().IsActivated() && client->getStatus() == beam::ethereum::Client::Status::Connected;
     }
     auto client = AppModel::getInstance().getSwapCoinClient(swapCoin);
-    return client->GetSettings().IsActivated() && client->getStatus() == beam::bitcoin::Client::Status::Connected;
+    return client && client->GetSettings().IsActivated() && client->getStatus() == beam::bitcoin::Client::Status::Connected;
 }
 
 QString QMLGlobals::getBeamUnit() const
@@ -407,7 +408,8 @@ QString QMLGlobals::getRecommendedFee(OldWalletCurrency::OldCurrency currency)
     }
 
     auto swapCoin = convertCurrencyToSwapCoin(currency);
-    return QString::fromStdString(std::to_string(AppModel::getInstance().getSwapCoinClient(swapCoin)->getEstimatedFeeRate()));
+    auto client = AppModel::getInstance().getSwapCoinClient(swapCoin);
+    return client ? QString::fromStdString(std::to_string(client->getEstimatedFeeRate())) : QString::fromStdString(std::to_string(0));
 }
 
 QString QMLGlobals::getDefaultFee(OldWalletCurrency::OldCurrency currency)
@@ -423,7 +425,8 @@ QString QMLGlobals::getDefaultFee(OldWalletCurrency::OldCurrency currency)
     }
 
     auto swapCoin = convertCurrencyToSwapCoin(currency);
-    return QString::fromStdString(std::to_string(AppModel::getInstance().getSwapCoinClient(swapCoin)->getEstimatedFeeRate()));
+    auto client = AppModel::getInstance().getSwapCoinClient(swapCoin);
+    return client ? QString::fromStdString(std::to_string(client->getEstimatedFeeRate())) : QString::fromStdString(std::to_string(0));
 }
 
 QString QMLGlobals::divideWithPrecision(const QString& dividend, const QString& divider, uint precision)

--- a/ui/viewmodel/qml_globals.cpp
+++ b/ui/viewmodel/qml_globals.cpp
@@ -418,15 +418,7 @@ QString QMLGlobals::getDefaultFee(OldWalletCurrency::OldCurrency currency)
     {
         return QString::fromStdString(std::to_string(minFeeBeam()));
     }
-
-    if (isEthereumBased(currency))
-    {
-        return QString::fromStdString(std::to_string(AppModel::getInstance().getSwapEthClient()->getGasPrice()));
-    }
-
-    auto swapCoin = convertCurrencyToSwapCoin(currency);
-    auto client = AppModel::getInstance().getSwapCoinClient(swapCoin);
-    return client ? QString::fromStdString(std::to_string(client->getEstimatedFeeRate())) : QString::fromStdString(std::to_string(0));
+    return getRecommendedFee(currency);
 }
 
 QString QMLGlobals::divideWithPrecision(const QString& dividend, const QString& divider, uint precision)

--- a/ui/viewmodel/receive_swap_view.cpp
+++ b/ui/viewmodel/receive_swap_view.cpp
@@ -20,7 +20,11 @@
 #include "qml_globals.h"
 #include "fee_helpers.h"
 #include "wallet/transactions/swaps/bridges/ethereum/ethereum_side.h"
+#include "wallet/transactions/swaps/bridges/ethereum/common.h"
 #include "atomic_swap/swap_utils.h"
+#include "model/assets_manager.h"
+#include "model/settings.h"
+#include <algorithm>
 
 namespace {
     enum
@@ -82,6 +86,54 @@ ReceiveSwapViewModel::ReceiveSwapViewModel()
     connect(_walletModel,  &WalletModel::coinsSelected, this, &ReceiveSwapViewModel::onCoinsSelected);
     connect(_rates.get(), &ExchangeRatesManager::rateUnitChanged, this, &ReceiveSwapViewModel::secondCurrencyUnitNameChanged);
     connect(_rates.get(), &ExchangeRatesManager::activeRateChanged, this, &ReceiveSwapViewModel::secondCurrencyRateChanged);
+    connect(AppModel::getInstance().getAssets().get(), &AssetsManager::assetsListChanged, this, [this]()
+    {
+        // assets feed currList (one entry per asset), so a change there
+        // reshuffles both the combo model and index mapping
+        emit currListChanged();
+        emit sentCurrencyIndexChanged();
+        emit receiveCurrencyIndexChanged();
+        if (_selectedBeamAssetId != 0)
+        {
+            // drop the selection if its asset vanished from the wallet
+            for (const auto& asset : AppModel::getInstance().getAssets()->getAssetsList())
+            {
+                if (asset.value("assetId").toUInt() == static_cast<uint>(_selectedBeamAssetId))
+                {
+                    return;
+                }
+            }
+            setSelectedBeamAssetId(0);
+        }
+    });
+    connect(&AppModel::getInstance().getSettings(), &WalletSettings::ethCustomTokensChanged, this, [this]()
+    {
+        // the stored token list feeds currList (one entry per token), so a
+        // change there reshuffles both the combo model and index mapping
+        emit currListChanged();
+        emit sentCurrencyIndexChanged();
+        emit receiveCurrencyIndexChanged();
+        if (!_selectedTokenContract.isEmpty())
+        {
+            // drop the selection if its token was removed in the settings
+            for (const auto& token : getCustomTokensList())
+            {
+                if (token.value("contract").toString() == _selectedTokenContract)
+                {
+                    return;
+                }
+            }
+            setSelectedTokenContract(QString());
+        }
+    });
+    // the combo index depends on both the settled currency and (for the
+    // Ethereum side) which token is stamped; keep it in sync with either
+    connect(this, &ReceiveSwapViewModel::sentCurrencyChanged, this, &ReceiveSwapViewModel::sentCurrencyIndexChanged);
+    connect(this, &ReceiveSwapViewModel::receiveCurrencyChanged, this, &ReceiveSwapViewModel::receiveCurrencyIndexChanged);
+    connect(this, &ReceiveSwapViewModel::selectedTokenChanged, this, &ReceiveSwapViewModel::sentCurrencyIndexChanged);
+    connect(this, &ReceiveSwapViewModel::selectedTokenChanged, this, &ReceiveSwapViewModel::receiveCurrencyIndexChanged);
+    connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::sentCurrencyIndexChanged);
+    connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::receiveCurrencyIndexChanged);
 
     generateNewAddress();
     updateTransactionToken();
@@ -135,13 +187,13 @@ QString ReceiveSwapViewModel::getRate() const
 
     if (!beamAmount) return QString();
 
-    beamui::Currencies otherCurrency =
-        convertCurrency(isSendBeam() ? _receiveCurrency : _sentCurrency);
+    auto otherOldCurrency = isSendBeam() ? _receiveCurrency : _sentCurrency;
+    uint8_t otherDecimals = effectiveDecimals(otherOldCurrency);
 
     return QMLGlobals::divideWithPrecision(
-        beamui::AmountToUIString(otherCoinAmount, otherCurrency, false), 
+        beamui::AmountToUIStringExactDecimals(otherCoinAmount, otherDecimals),
         beamui::AmountToUIString(beamAmount),
-        beamui::getCurrencyDecimals(otherCurrency));
+        otherDecimals);
 }
 
 void ReceiveSwapViewModel::onSwapParamsLoaded(const beam::ByteBuffer& params)
@@ -202,12 +254,12 @@ void ReceiveSwapViewModel::onCoinsSelected(const beam::wallet::CoinsSelectionInf
 
 QString ReceiveSwapViewModel::getAmountToReceive() const
 {
-    return beamui::AmountToUIString(_amountToReceiveGrothes, convertCurrency(_receiveCurrency), false);
+    return beamui::AmountToUIStringExactDecimals(_amountToReceiveGrothes, effectiveDecimals(_receiveCurrency));
 }
 
 void ReceiveSwapViewModel::setAmountToReceive(QString value)
 {
-    auto amount = beamui::UIStringToAmount(value, convertCurrency(_receiveCurrency));
+    auto amount = beamui::UIStringToAmountExactDecimals(value, effectiveDecimals(_receiveCurrency));
     if (amount != _amountToReceiveGrothes)
     {
         _amountToReceiveGrothes = amount;
@@ -219,7 +271,7 @@ void ReceiveSwapViewModel::setAmountToReceive(QString value)
 
 QString ReceiveSwapViewModel::getAmountSent() const
 {
-    return beamui::AmountToUIString(_amountSentGrothes, convertCurrency(_sentCurrency), false);
+    return beamui::AmountToUIStringExactDecimals(_amountSentGrothes, effectiveDecimals(_sentCurrency));
 }
 
 unsigned int ReceiveSwapViewModel::getReceiveFee() const
@@ -229,7 +281,7 @@ unsigned int ReceiveSwapViewModel::getReceiveFee() const
 
 void ReceiveSwapViewModel::setAmountSent(QString value)
 {
-    auto amount = beamui::UIStringToAmount(value, convertCurrency(_sentCurrency));
+    auto amount = beamui::UIStringToAmountExactDecimals(value, effectiveDecimals(_sentCurrency));
     if (amount != _amountSentGrothes)
     {
         bool isPreviouseSendWasZero = _amountSentGrothes == 0;
@@ -292,6 +344,9 @@ void ReceiveSwapViewModel::setReceiveCurrency(OldWalletCurrency::OldCurrency val
         // different units for different currencies. example BTC and ETH
         QString amount = getAmountToReceive();
         _receiveCurrency = value;
+        // deferred: the QML sides-flip updates sent/receive currency one binding at
+        // a time, so the pair passes through transient states here
+        QMetaObject::invokeMethod(this, &ReceiveSwapViewModel::syncExtendedSelections, Qt::QueuedConnection);
         setAmountToReceive(amount);
         emit receiveCurrencyChanged();
         updateTransactionToken();
@@ -315,6 +370,9 @@ void ReceiveSwapViewModel::setSentCurrency(OldWalletCurrency::OldCurrency value)
         // different units for different currencies. example BTC and ETH
         QString amount = getAmountSent();
         _sentCurrency = value;
+        // deferred: the QML sides-flip updates sent/receive currency one binding at
+        // a time, so the pair passes through transient states here
+        QMetaObject::invokeMethod(this, &ReceiveSwapViewModel::syncExtendedSelections, Qt::QueuedConnection);
         setAmountSent(amount);
         emit sentCurrencyChanged();
         updateTransactionToken();
@@ -412,12 +470,27 @@ bool ReceiveSwapViewModel::isEnough() const
 
     if (_sentCurrency == OldWalletCurrency::OldCurrency::CurrBeam)
     {
+        if (_selectedBeamAssetId != 0)
+        {
+            // the offered value is a Confidential Asset; the fee is still paid in BEAM
+            return _walletModel->getAvailable(_selectedBeamAssetId) >= beam::AmountBig::Number(_amountSentGrothes) &&
+                   _walletModel->getAvailable(beam::Asset::s_BeamID) >= beam::AmountBig::Number(_sentFeeGrothes);
+        }
         return _walletModel->getAvailable(beam::Asset::s_BeamID) >= total;
     }
 
     auto swapCoin = convertCurrencyToSwapCoin(_sentCurrency);
     if (isEthereumBased(_sentCurrency))
     {
+        if (isTokenSide(_sentCurrency))
+        {
+            // no live balance for arbitrary custom tokens: only check the ETH
+            // that pays the lock gas (incl. the approve calls, kApproveTxGasLimit)
+            const beam::Amount lockFee = _sentFeeGrothes *
+                (beam::ethereum::kLockTxGasLimit + 2 * beam::ethereum::kApproveTxGasLimit);
+            return AppModel::getInstance().getSwapEthClient()->getAvailable(beam::wallet::AtomicSwapCoin::Ethereum) >= lockFee;
+        }
+
         if (_sentCurrency == OldWalletCurrency::OldCurrency::CurrEthereum)
         {
             total = _amountSentGrothes + beam::wallet::EthereumSide::CalcLockTxFee(_sentFeeGrothes, swapCoin);
@@ -517,8 +590,14 @@ void ReceiveSwapViewModel::updateTransactionToken()
     emit isReceiveFeeOKChanged();
 
     _isBeamSide = (_sentCurrency == OldWalletCurrency::OldCurrency::CurrBeam);
-    auto swapCoin   = convertCurrencyToSwapCoin(
-        _isBeamSide ? _receiveCurrency : _sentCurrency);
+    const auto otherCurrency = _isBeamSide ? _receiveCurrency : _sentCurrency;
+
+    // a custom ERC-20 token replaces plain Ethereum as the swap coin: the core
+    // (EthereumSide::IsERC20Token, offers board ExtendedOffer wire coin) keys on
+    // AtomicSwapCoin::Erc20Token, the contract itself travels in param 43
+    const bool tokenActive = isTokenSide(otherCurrency);
+    auto swapCoin = tokenActive ? beam::wallet::AtomicSwapCoin::Erc20Token
+                                : convertCurrencyToSwapCoin(otherCurrency);
     auto beamAmount =
         _isBeamSide ? _amountSentGrothes : _amountToReceiveGrothes;
     auto swapAmount =
@@ -529,12 +608,34 @@ void ReceiveSwapViewModel::updateTransactionToken()
 
     QPointer<ReceiveSwapViewModel> guard = this;
 
-    auto onSwapParams = [guard, this](beam::wallet::TxParameters&& params)
+    auto onSwapParams = [guard, this, tokenActive](beam::wallet::TxParameters&& params)
     {
         if (!guard)
             return;
 
         _txParameters = std::move(params);
+
+        // both stampings re-checked against the current pair here: stale
+        // selections must never ride on an unrelated offer
+        if (_selectedBeamAssetId != 0 &&
+            (_sentCurrency == OldWalletCurrency::OldCurrency::CurrBeam ||
+             _receiveCurrency == OldWalletCurrency::OldCurrency::CurrBeam))
+        {
+            _txParameters.SetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetID,
+                                        beam::Asset::ID(_selectedBeamAssetId));
+            _txParameters.SetParameter(beam::wallet::TxParameterID::AtomicSwapBeamAssetName,
+                                        getSelectedBeamAssetUnitName().toStdString());
+        }
+
+        if (tokenActive && !_selectedTokenContract.isEmpty())
+        {
+            _txParameters.SetParameter(beam::wallet::TxParameterID::AtomicSwapTokenContract,
+                                        _selectedTokenContract.toStdString());
+            _txParameters.SetParameter(beam::wallet::TxParameterID::AtomicSwapTokenSymbol,
+                                        _selectedTokenSymbol.toStdString());
+            _txParameters.SetParameter(beam::wallet::TxParameterID::AtomicSwapTokenDecimals,
+                                        static_cast<uint8_t>(_selectedTokenDecimals));
+        }
 
 #ifdef BEAM_CLIENT_VERSION
         _txParameters.SetParameter(
@@ -611,5 +712,291 @@ QString ReceiveSwapViewModel::getReceiveFeeTitle() const
 
 QList<QMap<QString, QVariant>> ReceiveSwapViewModel::getCurrList() const
 {
-    return swapui::getUICurrList();
+    auto list = swapui::getUICurrList();
+
+    // Confidential Assets ride the BEAM swap side; each known asset gets its
+    // own entry appended after the classic currencies so it is picked in the
+    // same combo as BEAM/BTC/.../WBTC. "assetId" marks these entries for
+    // selectCurrencyByListIndex/currencyToListIndex.
+    for (const auto& asset : AppModel::getInstance().getAssets()->getAssetsList())
+    {
+        const auto assetId = asset.value("assetId").toUInt();
+        if (assetId == static_cast<uint>(beam::Asset::s_BeamID))
+        {
+            continue;
+        }
+
+        QMap<QString, QVariant> entry;
+        const auto name = asset.value("unitName").toString();
+
+        entry.insert("isBEAM", true);
+        entry.insert("unitName", name);
+        entry.insert("unitNameWithId", QString("%1 (%2)").arg(name).arg(assetId));
+        entry.insert("icon", asset.value("icon"));
+        entry.insert("iconWidth", 22);
+        entry.insert("iconHeight", 22);
+        entry.insert("decimals", beamui::getCurrencyDecimals(beamui::Currencies::Beam));
+        entry.insert("assetId", assetId);
+
+        list.push_back(entry);
+    }
+
+    // stored custom ERC-20 tokens ride the Ethereum swap coin; each gets its
+    // own entry appended after the classic currencies so it is picked in the
+    // same combo as BEAM/BTC/.../WBTC (issue #1267). "tokenContract" marks
+    // these entries for selectCurrencyByListIndex/currencyToListIndex; classic
+    // entries simply don't carry the key (falsy/empty when read back in QML).
+    for (const auto& token : getCustomTokensList())
+    {
+        QMap<QString, QVariant> entry;
+        const auto symbol = token.value("symbol").toString();
+        const auto decimals = std::min(token.value("decimals").toUInt(), 9u);
+
+        entry.insert("isBEAM", false);
+        entry.insert("unitName", symbol);
+        entry.insert("unitNameWithId", symbol);
+        // the combo delegate only renders a file icon (SvgImage source path,
+        // no room for the generated TokenIcon glyph); reuse the ETH icon
+        entry.insert("icon", "qrc:/assets/icon-eth.svg");
+        entry.insert("iconWidth", 22);
+        entry.insert("iconHeight", 22);
+        entry.insert("decimals", decimals);
+        entry.insert("tokenContract", token.value("contract"));
+
+        list.push_back(entry);
+    }
+
+    return list;
+}
+
+unsigned int ReceiveSwapViewModel::getSelectedBeamAssetId() const
+{
+    return static_cast<unsigned int>(_selectedBeamAssetId);
+}
+
+void ReceiveSwapViewModel::setSelectedBeamAssetId(unsigned int value)
+{
+    auto assetId = static_cast<beam::Asset::ID>(value);
+    if (assetId != _selectedBeamAssetId)
+    {
+        _selectedBeamAssetId = assetId;
+        emit selectedBeamAssetChanged();
+        emit currListChanged();
+        emit enoughChanged();
+        updateTransactionToken();
+    }
+}
+
+QString ReceiveSwapViewModel::getSelectedBeamAssetUnitName() const
+{
+    if (_selectedBeamAssetId == 0)
+    {
+        return QMLGlobals::getCurrencyUnitName(OldWalletCurrency::OldCurrency::CurrBeam);
+    }
+    return AppModel::getInstance().getAssets()->getUnitName(_selectedBeamAssetId, AssetsManager::NoShorten);
+}
+
+QList<QMap<QString, QVariant>> ReceiveSwapViewModel::getCustomTokensList() const
+{
+    return AppModel::getInstance().getSettings().getEthCustomTokens();
+}
+
+QString ReceiveSwapViewModel::getSelectedTokenContract() const
+{
+    return _selectedTokenContract;
+}
+
+void ReceiveSwapViewModel::setSelectedTokenContract(const QString& value)
+{
+    if (value == _selectedTokenContract)
+    {
+        return;
+    }
+
+    // the eth-side amount is stored in wallet units whose scale follows the
+    // selected token's decimals: keep the typed value, not the raw units
+    const bool sentIsEth = _sentCurrency == OldWalletCurrency::OldCurrency::CurrEthereum;
+    const bool receiveIsEth = _receiveCurrency == OldWalletCurrency::OldCurrency::CurrEthereum;
+    const QString ethSideAmount = sentIsEth ? getAmountSent()
+                                : receiveIsEth ? getAmountToReceive() : QString();
+
+    _selectedTokenContract = value;
+    _selectedTokenSymbol.clear();
+    _selectedTokenDecimals = 0;
+
+    if (!value.isEmpty())
+    {
+        for (const auto& token : getCustomTokensList())
+        {
+            if (token.value("contract").toString() == value)
+            {
+                _selectedTokenSymbol = token.value("symbol").toString();
+                _selectedTokenDecimals = token.value("decimals").toUInt();
+                break;
+            }
+        }
+    }
+
+    emit selectedTokenChanged();
+    emit currListChanged();
+
+    if (sentIsEth)
+    {
+        setAmountSent(ethSideAmount);
+        emit amountSentChanged();
+    }
+    else if (receiveIsEth)
+    {
+        setAmountToReceive(ethSideAmount);
+        emit amountReceiveChanged();
+    }
+
+    updateTransactionToken();
+}
+
+QString ReceiveSwapViewModel::getSelectedTokenSymbol() const
+{
+    return _selectedTokenSymbol;
+}
+
+unsigned int ReceiveSwapViewModel::getSelectedTokenDecimals() const
+{
+    return _selectedTokenDecimals;
+}
+
+int ReceiveSwapViewModel::getSentCurrencyIndex() const
+{
+    return currencyToListIndex(_sentCurrency);
+}
+
+void ReceiveSwapViewModel::setSentCurrencyIndex(int index)
+{
+    selectCurrencyByListIndex(true, index);
+}
+
+int ReceiveSwapViewModel::getReceiveCurrencyIndex() const
+{
+    return currencyToListIndex(_receiveCurrency);
+}
+
+void ReceiveSwapViewModel::setReceiveCurrencyIndex(int index)
+{
+    selectCurrencyByListIndex(false, index);
+}
+
+int ReceiveSwapViewModel::currencyToListIndex(OldWalletCurrency::OldCurrency currency) const
+{
+    if (currency == OldWalletCurrency::OldCurrency::CurrBeam && _selectedBeamAssetId != 0)
+    {
+        const auto list = getCurrList();
+        for (int i = 0; i < list.size(); ++i)
+        {
+            if (list[i].value("assetId").toUInt() == static_cast<uint>(_selectedBeamAssetId))
+            {
+                return i;
+            }
+        }
+        // the selected asset vanished from the wallet's list; fall back to
+        // the plain BEAM slot
+        return static_cast<int>(OldWalletCurrency::OldCurrency::CurrBeam);
+    }
+    if (isTokenSide(currency))
+    {
+        const auto list = getCurrList();
+        for (int i = 0; i < list.size(); ++i)
+        {
+            if (list[i].value("tokenContract").toString() == _selectedTokenContract)
+            {
+                return i;
+            }
+        }
+        // the selected token vanished from settings mid-flight (race with
+        // syncExtendedSelections); fall back to the plain Ethereum slot
+        return static_cast<int>(OldWalletCurrency::OldCurrency::CurrEthereum);
+    }
+    return static_cast<int>(currency);
+}
+
+void ReceiveSwapViewModel::selectCurrencyByListIndex(bool isSent, int index)
+{
+    const auto list = getCurrList();
+    if (index < 0 || index >= list.size())
+    {
+        // a stale/removed entry (e.g. combo model changed underneath a
+        // pending selection): ignore rather than crash
+        return;
+    }
+
+    const auto contract = list[index].value("tokenContract").toString();
+    const auto assetId = list[index].value("assetId").toUInt();
+    const auto currency = !contract.isEmpty() ? OldWalletCurrency::OldCurrency::CurrEthereum
+        : assetId != 0                        ? OldWalletCurrency::OldCurrency::CurrBeam
+                                              : static_cast<OldWalletCurrency::OldCurrency>(index);
+
+    if (!contract.isEmpty())
+    {
+        // stamp the token identity before flipping the enum so
+        // isTokenSide()/effectiveDecimals() already see it once
+        // setSentCurrency/setReceiveCurrency runs its amount conversion
+        setSelectedTokenContract(contract);
+    }
+    else if (currency == OldWalletCurrency::OldCurrency::CurrEthereum)
+    {
+        // explicit "plain ETH" pick on a side that already was Ethereum:
+        // syncExtendedSelections() only clears once neither side is
+        // Ethereum anymore, so drop the stale token stamp here
+        setSelectedTokenContract(QString());
+    }
+
+    if (assetId != 0)
+    {
+        setSelectedBeamAssetId(assetId);
+    }
+    else if (currency == OldWalletCurrency::OldCurrency::CurrBeam)
+    {
+        // explicit plain-BEAM pick drops a stale asset stamp
+        setSelectedBeamAssetId(0);
+    }
+
+    if (isSent)
+    {
+        setSentCurrency(currency);
+    }
+    else
+    {
+        setReceiveCurrency(currency);
+    }
+}
+
+bool ReceiveSwapViewModel::isTokenSide(OldWalletCurrency::OldCurrency currency) const
+{
+    return currency == OldWalletCurrency::OldCurrency::CurrEthereum && !_selectedTokenContract.isEmpty();
+}
+
+uint8_t ReceiveSwapViewModel::effectiveDecimals(OldWalletCurrency::OldCurrency currency) const
+{
+    if (isTokenSide(currency))
+    {
+        // core stores AtomicSwapAmount in 10^min(decimals, 9) units per token
+        // (WalletUnitsPerToken, swaps/bridges/ethereum/common.cpp)
+        return static_cast<uint8_t>(std::min(_selectedTokenDecimals, 9u));
+    }
+    return beamui::getCurrencyDecimals(convertCurrency(currency));
+}
+
+void ReceiveSwapViewModel::syncExtendedSelections()
+{
+    if (_selectedBeamAssetId != 0 &&
+        _sentCurrency != OldWalletCurrency::OldCurrency::CurrBeam &&
+        _receiveCurrency != OldWalletCurrency::OldCurrency::CurrBeam)
+    {
+        setSelectedBeamAssetId(0);
+    }
+
+    if (!_selectedTokenContract.isEmpty() &&
+        _sentCurrency != OldWalletCurrency::OldCurrency::CurrEthereum &&
+        _receiveCurrency != OldWalletCurrency::OldCurrency::CurrEthereum)
+    {
+        setSelectedTokenContract(QString());
+    }
 }

--- a/ui/viewmodel/receive_swap_view.cpp
+++ b/ui/viewmodel/receive_swap_view.cpp
@@ -135,8 +135,32 @@ ReceiveSwapViewModel::ReceiveSwapViewModel()
     connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::sentCurrencyIndexChanged);
     connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::receiveCurrencyIndexChanged);
 
+    const auto onFeeRates = [this]()
+    {
+        ++_feeRatesRevision;
+        emit feeRatesRevisionChanged();
+    };
+    if (auto ethClient = AppModel::getInstance().getSwapEthClient(); ethClient)
+    {
+        connect(ethClient.get(), &SwapEthClientModel::estimatedFeeRateChanged, this, onFeeRates);
+    }
+    for (auto coin : {beam::wallet::AtomicSwapCoin::Bitcoin, beam::wallet::AtomicSwapCoin::Litecoin,
+                      beam::wallet::AtomicSwapCoin::Qtum, beam::wallet::AtomicSwapCoin::Dogecoin,
+                      beam::wallet::AtomicSwapCoin::Dash, beam::wallet::AtomicSwapCoin::Bitcoin_Cash})
+    {
+        if (auto client = AppModel::getInstance().getSwapCoinClient(coin); client)
+        {
+            connect(client.get(), &SwapCoinClientModel::estimatedFeeRateChanged, this, onFeeRates);
+        }
+    }
+
     generateNewAddress();
     updateTransactionToken();
+}
+
+unsigned int ReceiveSwapViewModel::getFeeRatesRevision() const
+{
+    return _feeRatesRevision;
 }
 
 //void ReceiveSwapViewModel::onGeneratedNewAddress(const beam::wallet::WalletAddress& addr)

--- a/ui/viewmodel/receive_swap_view.cpp
+++ b/ui/viewmodel/receive_swap_view.cpp
@@ -135,24 +135,11 @@ ReceiveSwapViewModel::ReceiveSwapViewModel()
     connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::sentCurrencyIndexChanged);
     connect(this, &ReceiveSwapViewModel::selectedBeamAssetChanged, this, &ReceiveSwapViewModel::receiveCurrencyIndexChanged);
 
-    const auto onFeeRates = [this]()
+    swapui::connectFeeRateClients(this, [this]()
     {
         ++_feeRatesRevision;
         emit feeRatesRevisionChanged();
-    };
-    if (auto ethClient = AppModel::getInstance().getSwapEthClient(); ethClient)
-    {
-        connect(ethClient.get(), &SwapEthClientModel::estimatedFeeRateChanged, this, onFeeRates);
-    }
-    for (auto coin : {beam::wallet::AtomicSwapCoin::Bitcoin, beam::wallet::AtomicSwapCoin::Litecoin,
-                      beam::wallet::AtomicSwapCoin::Qtum, beam::wallet::AtomicSwapCoin::Dogecoin,
-                      beam::wallet::AtomicSwapCoin::Dash, beam::wallet::AtomicSwapCoin::Bitcoin_Cash})
-    {
-        if (auto client = AppModel::getInstance().getSwapCoinClient(coin); client)
-        {
-            connect(client.get(), &SwapCoinClientModel::estimatedFeeRateChanged, this, onFeeRates);
-        }
-    }
+    });
 
     generateNewAddress();
     updateTransactionToken();
@@ -508,11 +495,7 @@ bool ReceiveSwapViewModel::isEnough() const
     {
         if (isTokenSide(_sentCurrency))
         {
-            // no live balance for arbitrary custom tokens: only check the ETH
-            // that pays the lock gas (incl. the approve calls, kApproveTxGasLimit)
-            const beam::Amount lockFee = _sentFeeGrothes *
-                (beam::ethereum::kLockTxGasLimit + 2 * beam::ethereum::kApproveTxGasLimit);
-            return AppModel::getInstance().getSwapEthClient()->getAvailable(beam::wallet::AtomicSwapCoin::Ethereum) >= lockFee;
+            return swapui::enoughEthForTokenLock(_sentFeeGrothes);
         }
 
         if (_sentCurrency == OldWalletCurrency::OldCurrency::CurrEthereum)
@@ -774,7 +757,7 @@ QList<QMap<QString, QVariant>> ReceiveSwapViewModel::getCurrList() const
     {
         QMap<QString, QVariant> entry;
         const auto symbol = token.value("symbol").toString();
-        const auto decimals = std::min(token.value("decimals").toUInt(), 9u);
+        const auto decimals = static_cast<uint>(beamui::tokenWalletDecimals(token.value("decimals").toUInt()));
 
         entry.insert("isBEAM", false);
         entry.insert("unitName", symbol);
@@ -994,18 +977,12 @@ void ReceiveSwapViewModel::selectCurrencyByListIndex(bool isSent, int index)
 
 bool ReceiveSwapViewModel::isTokenSide(OldWalletCurrency::OldCurrency currency) const
 {
-    return currency == OldWalletCurrency::OldCurrency::CurrEthereum && !_selectedTokenContract.isEmpty();
+    return swapui::isTokenSide(currency, _selectedTokenContract);
 }
 
 uint8_t ReceiveSwapViewModel::effectiveDecimals(OldWalletCurrency::OldCurrency currency) const
 {
-    if (isTokenSide(currency))
-    {
-        // core stores AtomicSwapAmount in 10^min(decimals, 9) units per token
-        // (WalletUnitsPerToken, swaps/bridges/ethereum/common.cpp)
-        return static_cast<uint8_t>(std::min(_selectedTokenDecimals, 9u));
-    }
-    return beamui::getCurrencyDecimals(convertCurrency(currency));
+    return swapui::effectiveSwapDecimals(currency, _selectedTokenContract, _selectedTokenDecimals);
 }
 
 void ReceiveSwapViewModel::syncExtendedSelections()

--- a/ui/viewmodel/receive_swap_view.h
+++ b/ui/viewmodel/receive_swap_view.h
@@ -59,6 +59,8 @@ class ReceiveSwapViewModel: public QObject
     // sentCurrency==CurrEthereum + the underlying _selectedTokenContract stamp.
     Q_PROPERTY(int           sentCurrencyIndex                   READ getSentCurrencyIndex     WRITE setSentCurrencyIndex     NOTIFY sentCurrencyIndexChanged)
     Q_PROPERTY(int           receiveCurrencyIndex                READ getReceiveCurrencyIndex  WRITE setReceiveCurrencyIndex  NOTIFY receiveCurrencyIndexChanged)
+    // bumped on estimatedFeeRateChanged so QML fee bindings re-evaluate
+    Q_PROPERTY(unsigned int  feeRatesRevision                    READ getFeeRatesRevision      NOTIFY feeRatesRevisionChanged)
 
 public:
     ReceiveSwapViewModel();
@@ -89,6 +91,7 @@ signals:
     void selectedTokenChanged();
     void sentCurrencyIndexChanged();
     void receiveCurrencyIndexChanged();
+    void feeRatesRevisionChanged();
 
 public:
     Q_INVOKABLE void generateNewAddress();
@@ -173,6 +176,8 @@ private:
     int currencyToListIndex(OldWalletCurrency::OldCurrency currency) const;
     void selectCurrencyByListIndex(bool isSent, int index);
 
+    unsigned int getFeeRatesRevision() const;
+
 private slots:
     //void onGeneratedNewAddress(const beam::wallet::WalletAddress& walletAddr);
     void onSwapParamsLoaded(const beam::ByteBuffer& token);
@@ -207,4 +212,6 @@ private:
     QString _selectedTokenContract;
     QString _selectedTokenSymbol;
     unsigned int _selectedTokenDecimals = 0;
+
+    unsigned int _feeRatesRevision = 0;
 };

--- a/ui/viewmodel/receive_swap_view.h
+++ b/ui/viewmodel/receive_swap_view.h
@@ -47,6 +47,19 @@ class ReceiveSwapViewModel: public QObject
     Q_PROPERTY(unsigned int minimalBeamFeeGrothes           READ getMinimalBeamFeeGrothes       NOTIFY  minimalBeamFeeGrothesChanged)
     Q_PROPERTY(QList<QMap<QString, QVariant>> currList      READ getCurrList                    NOTIFY  currListChanged)
 
+    Q_PROPERTY(unsigned int  selectedBeamAssetId                 READ getSelectedBeamAssetId    WRITE setSelectedBeamAssetId  NOTIFY  selectedBeamAssetChanged)
+    Q_PROPERTY(QString       selectedBeamAssetUnitName            READ getSelectedBeamAssetUnitName                     NOTIFY  selectedBeamAssetChanged)
+
+    // custom ERC-20 tokens stored per wallet (settings, added via the ethereum
+    // settings pane): each is appended to currList as its own entry (after the
+    // classic currencies) so it is picked in the SAME combo as BEAM/BTC/.../WBTC.
+    // OldCurrency stays a closed enum (extending it would ripple through every
+    // exhaustive switch over it); instead the combo index identifies the entry,
+    // and sentCurrencyIndex/receiveCurrencyIndex translate that index to/from
+    // sentCurrency==CurrEthereum + the underlying _selectedTokenContract stamp.
+    Q_PROPERTY(int           sentCurrencyIndex                   READ getSentCurrencyIndex     WRITE setSentCurrencyIndex     NOTIFY sentCurrencyIndexChanged)
+    Q_PROPERTY(int           receiveCurrencyIndex                READ getReceiveCurrencyIndex  WRITE setReceiveCurrencyIndex  NOTIFY receiveCurrencyIndexChanged)
+
 public:
     ReceiveSwapViewModel();
 
@@ -72,6 +85,10 @@ signals:
     void secondCurrencyUnitNameChanged();
     void minimalBeamFeeGrothesChanged();
     void currListChanged();
+    void selectedBeamAssetChanged();
+    void selectedTokenChanged();
+    void sentCurrencyIndexChanged();
+    void receiveCurrencyIndexChanged();
 
 public:
     Q_INVOKABLE void generateNewAddress();
@@ -119,6 +136,13 @@ private:
     void loadSwapParams();
     void storeSwapParams();
 
+    // true when @currency is the pair side the selected custom ERC-20 token rides on
+    bool isTokenSide(OldWalletCurrency::OldCurrency currency) const;
+    // token side -> min(token decimals, 9) (WalletUnitsPerToken rule), otherwise the classic table
+    uint8_t effectiveDecimals(OldWalletCurrency::OldCurrency currency) const;
+    // drops the asset/token selections that no longer match the chosen pair
+    void syncExtendedSelections();
+
     bool isSendBeam() const;
     QString getRate() const;
 
@@ -130,6 +154,24 @@ private:
 
     unsigned int getMinimalBeamFeeGrothes() const;
     QList<QMap<QString, QVariant>> getCurrList() const;
+
+    unsigned int getSelectedBeamAssetId() const;
+    void setSelectedBeamAssetId(unsigned int value);
+    QString getSelectedBeamAssetUnitName() const;
+
+    QList<QMap<QString, QVariant>> getCustomTokensList() const;
+    QString getSelectedTokenContract() const;
+    void setSelectedTokenContract(const QString& value);
+    QString getSelectedTokenSymbol() const;
+    unsigned int getSelectedTokenDecimals() const;
+
+    // combo index (into currList) <-> (sentCurrency/receiveCurrency, _selectedTokenContract)
+    int getSentCurrencyIndex() const;
+    void setSentCurrencyIndex(int index);
+    int getReceiveCurrencyIndex() const;
+    void setReceiveCurrencyIndex(int index);
+    int currencyToListIndex(OldWalletCurrency::OldCurrency currency) const;
+    void selectCurrencyByListIndex(bool isSent, int index);
 
 private slots:
     //void onGeneratedNewAddress(const beam::wallet::WalletAddress& walletAddr);
@@ -157,4 +199,12 @@ private:
 
     beam::Amount _minimalBeamFeeGrothes;
     bool _feeChangedByUI = false;
+
+    // Confidential Asset being offered on the BEAM side, 0 == plain BEAM
+    beam::Asset::ID _selectedBeamAssetId = 0;
+
+    // custom ERC-20 token being offered on the non-BEAM side, empty == none
+    QString _selectedTokenContract;
+    QString _selectedTokenSymbol;
+    unsigned int _selectedTokenDecimals = 0;
 };

--- a/ui/viewmodel/send_swap_view.cpp
+++ b/ui/viewmodel/send_swap_view.cpp
@@ -20,6 +20,7 @@
 #include "fee_helpers.h"
 #include "atomic_swap/swap_utils.h"
 #include "wallet/transactions/swaps/bridges/ethereum/ethereum_side.h"
+#include "wallet/transactions/swaps/bridges/ethereum/common.h"
 #include <algorithm>
 #include <regex>
 
@@ -66,19 +67,39 @@ void SendSwapViewModel::fillParameters(const beam::wallet::TxParameters& paramet
     if (peerAddr && swapAmount && beamAmount && swapCoin && isBeamSide
         && peerResponseTime && offeredTime && minHeight)
     {
+        // extended-offer fields first: the amount/currency setters below key the
+        // conversion decimals on them for ERC-20 offers
+        auto tokenContract = parameters.GetParameter<std::string>(TxParameterID::AtomicSwapTokenContract);
+        auto tokenSymbol = parameters.GetParameter<std::string>(TxParameterID::AtomicSwapTokenSymbol);
+        auto tokenDecimals = parameters.GetParameter<uint8_t>(TxParameterID::AtomicSwapTokenDecimals);
+        _tokenContract = tokenContract ? QString::fromStdString(*tokenContract) : QString();
+        _tokenSymbol = tokenSymbol ? QString::fromStdString(*tokenSymbol) : QString();
+        _tokenDecimals = tokenDecimals ? *tokenDecimals : 0;
+
+        auto beamAssetId = parameters.GetParameter<Asset::ID>(TxParameterID::AtomicSwapBeamAssetID);
+        auto beamAssetName = parameters.GetParameter<std::string>(TxParameterID::AtomicSwapBeamAssetName);
+        _beamAssetId = beamAssetId ? *beamAssetId : 0;
+        _beamAssetUnitName = beamAssetName ? QString::fromStdString(*beamAssetName) : QString();
+
+        // Erc20Token has no OldCurrency of its own: it is handled as the
+        // Ethereum currency slot plus the token params above
+        const auto swapSideCurrency = (*swapCoin == AtomicSwapCoin::Erc20Token)
+            ? OldWalletCurrency::OldCurrency::CurrEthereum
+            : convertSwapCoinToCurrency(*swapCoin);
+
         if (*isBeamSide) // other participant is not a beam side
         {
             // Do not set fee, it is set automatically based on the currency param
             setSendCurrency(OldWalletCurrency::OldCurrency::CurrBeam);
             setSendAmount(beamui::AmountToUIString(*beamAmount));
-            setReceiveCurrency(convertSwapCoinToCurrency(*swapCoin));
-            setReceiveAmount(beamui::AmountToUIString(*swapAmount, beamui::convertSwapCoinToCurrency(*swapCoin), false));
+            setReceiveCurrency(swapSideCurrency);
+            setReceiveAmount(beamui::AmountToUIStringExactDecimals(*swapAmount, effectiveDecimals(swapSideCurrency)));
         }
         else
         {
             // Do not set fee, it is set automatically based on the currency param
-            setSendCurrency(convertSwapCoinToCurrency(*swapCoin));
-            setSendAmount(beamui::AmountToUIString(*swapAmount, beamui::convertSwapCoinToCurrency(*swapCoin), false));
+            setSendCurrency(swapSideCurrency);
+            setSendAmount(beamui::AmountToUIStringExactDecimals(*swapAmount, effectiveDecimals(swapSideCurrency)));
             setReceiveCurrency(OldWalletCurrency::OldCurrency::CurrBeam);
             setReceiveAmount(beamui::AmountToUIString(*beamAmount));
         }
@@ -92,6 +113,8 @@ void SendSwapViewModel::fillParameters(const beam::wallet::TxParameters& paramet
 
         _txParameters = parameters;
         _isBeamSide = *isBeamSide;
+
+        emit currListChanged(); // unit names/decimals follow the token/asset fields
     }
 
     _tokenGeneratebByNewAppVersionMessage.clear();
@@ -158,12 +181,12 @@ bool SendSwapViewModel::getParametersValid() const
 
 QString SendSwapViewModel::getSendAmount() const
 {
-    return beamui::AmountToUIString(_sendAmountGrothes, convertCurrency(_sendCurrency), false);
+    return beamui::AmountToUIStringExactDecimals(_sendAmountGrothes, effectiveDecimals(_sendCurrency));
 }
 
 void SendSwapViewModel::setSendAmount(QString value)
 {
-    const auto amount = beamui::UIStringToAmount(value, convertCurrency(_sendCurrency));
+    const auto amount = beamui::UIStringToAmountExactDecimals(value, effectiveDecimals(_sendCurrency));
     if (amount != _sendAmountGrothes)
     {
         _sendAmountGrothes = amount;
@@ -173,7 +196,7 @@ void SendSwapViewModel::setSendAmount(QString value)
 
         if (_sendCurrency == OldWalletCurrency::OldCurrency::CurrBeam && _walletModel->hasShielded(beam::Asset::s_BeamID))
         {
-            _walletModel->getAsync()->selectCoins(_sendAmountGrothes, _sendFeeGrothes, beam::Asset::s_BeamID);
+            _walletModel->getAsync()->selectCoins(_sendAmountGrothes, _sendFeeGrothes, _beamAssetId);
         }
     }
 }
@@ -195,7 +218,7 @@ void SendSwapViewModel::setSendFee(unsigned int value)
         if (_sendCurrency == OldWalletCurrency::OldCurrency::CurrBeam && _walletModel->hasShielded(beam::Asset::s_BeamID) && _sendAmountGrothes)
         {
             _feeChangedByUI = true;
-            _walletModel->getAsync()->selectCoins(_sendAmountGrothes, _sendFeeGrothes, beam::Asset::s_BeamID);
+            _walletModel->getAsync()->selectCoins(_sendAmountGrothes, _sendFeeGrothes, _beamAssetId);
         }
     }
 }
@@ -220,12 +243,12 @@ void SendSwapViewModel::setSendCurrency(OldWalletCurrency::OldCurrency value)
 
 QString SendSwapViewModel::getReceiveAmount() const
 {
-    return beamui::AmountToUIString(_receiveAmountGrothes, convertCurrency(_receiveCurrency), false);
+    return beamui::AmountToUIStringExactDecimals(_receiveAmountGrothes, effectiveDecimals(_receiveCurrency));
 }
 
 void SendSwapViewModel::setReceiveAmount(QString value)
 {
-    const auto amount = beamui::UIStringToAmount(value, convertCurrency(_receiveCurrency));
+    const auto amount = beamui::UIStringToAmountExactDecimals(value, effectiveDecimals(_receiveCurrency));
     if (amount != _receiveAmountGrothes)
     {
         _receiveAmountGrothes = amount;
@@ -314,12 +337,12 @@ void SendSwapViewModel::onChangeCalculated(beam::Amount changeAsset, beam::Amoun
 {
     using namespace beam;
 
-    // only BEAM used in swap for the moment
-    assert(assetID == Asset::s_BeamID);
     assert(AmountBig::get_Hi(changeAsset) == 0);
-    assert(changeBeam == AmountBig::get_Lo(changeAsset));
 
-    _changeGrothes = changeBeam;
+    // the balance check needs the change of what is being spent: the asset's
+    // change for an asset spend, BEAM change otherwise (the values coincide
+    // when assetID is BEAM)
+    _changeGrothes = AmountBig::get_Lo(changeAsset);
     emit enoughChanged();
     emit canSendChanged();
 }
@@ -344,8 +367,29 @@ void SendSwapViewModel::onCoinsSelected(const beam::wallet::CoinsSelectionInfo& 
 bool SendSwapViewModel::isEnough() const
 {
     auto total = _sendAmountGrothes + _sendFeeGrothes + _changeGrothes;
+
+    // acceptor receives a Confidential Asset on the peer's BEAM side: the
+    // redeem tx fee is a separate BEAM spend on top of whatever is checked below
+    if (needsBeamForRedeemFee())
+    {
+        auto beamAvailable = beam::AmountBig::get_Lo(_walletModel->getAvailable(beam::Asset::s_BeamID));
+        if (beamAvailable < _receiveFeeGrothes)
+        {
+            return false;
+        }
+    }
+
     if (OldWalletCurrency::OldCurrency::CurrBeam == _sendCurrency)
     {
+        if (_beamAssetId != 0)
+        {
+            // sending a Confidential Asset; the tx fee is still paid in BEAM
+            auto assetAvailable = beam::AmountBig::get_Lo(_walletModel->getAvailable(_beamAssetId));
+            auto beamAvailable = beam::AmountBig::get_Lo(_walletModel->getAvailable(beam::Asset::s_BeamID));
+            return assetAvailable >= _sendAmountGrothes + _changeGrothes &&
+                   beamAvailable >= _sendFeeGrothes;
+        }
+
         auto available = beam::AmountBig::get_Lo(_walletModel->getAvailable(beam::Asset::s_BeamID));
         return available >= total;
     }
@@ -353,6 +397,15 @@ bool SendSwapViewModel::isEnough() const
     auto swapCoin = convertCurrencyToSwapCoin(_sendCurrency);
     if (isEthereumBased(_sendCurrency))
     {
+        if (isTokenSide(_sendCurrency))
+        {
+            // no live balance for arbitrary custom tokens: only check the ETH
+            // that pays the lock gas (incl. the approve calls, kApproveTxGasLimit)
+            const beam::Amount lockFee = _sendFeeGrothes *
+                (beam::ethereum::kLockTxGasLimit + 2 * beam::ethereum::kApproveTxGasLimit);
+            return AppModel::getInstance().getSwapEthClient()->getAvailable(beam::wallet::AtomicSwapCoin::Ethereum) >= lockFee;
+        }
+
         if (_sendCurrency == OldWalletCurrency::OldCurrency::CurrEthereum)
         {
             total = _sendAmountGrothes + beam::wallet::EthereumSide::CalcLockTxFee(_sendFeeGrothes, swapCoin);
@@ -387,7 +440,7 @@ void SendSwapViewModel::recalcAvailable()
     {
     case OldWalletCurrency::OldCurrency::CurrBeam:
         _changeGrothes = 0;
-        _walletModel->getAsync()->calcChange(_sendAmountGrothes, _sendFeeGrothes, beam::Asset::s_BeamID);
+        _walletModel->getAsync()->calcChange(_sendAmountGrothes, _sendFeeGrothes, _beamAssetId);
         return;
     default:
         // TODO:SWAP implement for all currencies
@@ -481,13 +534,13 @@ QString SendSwapViewModel::getRate() const
 
     if (!beamAmount) return QString();
 
-    beamui::Currencies otherCurrency =
-        convertCurrency(isSendBeam() ? _receiveCurrency : _sendCurrency);
+    auto otherOldCurrency = isSendBeam() ? _receiveCurrency : _sendCurrency;
+    uint8_t otherDecimals = effectiveDecimals(otherOldCurrency);
 
     return QMLGlobals::divideWithPrecision(
-        beamui::AmountToUIString(otherCoinAmount, otherCurrency, false),
+        beamui::AmountToUIStringExactDecimals(otherCoinAmount, otherDecimals),
         beamui::AmountToUIString(beamAmount),
-        beamui::getCurrencyDecimals(otherCurrency));
+        otherDecimals);
 }
 
 QString SendSwapViewModel::getSecondCurrencySendRateValue() const
@@ -536,5 +589,82 @@ QString SendSwapViewModel::getReceiveFeeTitle() const
 
 QList<QMap<QString, QVariant>> SendSwapViewModel::getCurrList() const
 {
-    return swapui::getUICurrList();
+    auto list = swapui::getUICurrList();
+
+    // show the offer's real unit instead of "BEAM"/"ETH" for asset/token offers;
+    // the token entry also carries the token's wallet decimals
+    if (_beamAssetId != 0 && !_beamAssetUnitName.isEmpty())
+    {
+        auto& beamEntry = list[static_cast<int>(OldWalletCurrency::OldCurrency::CurrBeam)];
+        beamEntry["unitName"] = _beamAssetUnitName;
+        beamEntry["unitNameWithId"] = _beamAssetUnitName;
+        beamEntry["assetId"] = static_cast<uint>(_beamAssetId);
+    }
+
+    if (!_tokenContract.isEmpty())
+    {
+        auto& ethEntry = list[static_cast<int>(OldWalletCurrency::OldCurrency::CurrEthereum)];
+        const QString symbol = _tokenSymbol.isEmpty() ? QString("ERC20") : _tokenSymbol;
+        ethEntry["unitName"] = symbol;
+        ethEntry["unitNameWithId"] = symbol;
+        ethEntry["decimals"] = static_cast<uint>(std::min<uint8_t>(_tokenDecimals, 9));
+    }
+
+    return list;
+}
+
+bool SendSwapViewModel::isErc20Swap() const
+{
+    return !_tokenContract.isEmpty();
+}
+
+QString SendSwapViewModel::getTokenContract() const
+{
+    return _tokenContract;
+}
+
+QString SendSwapViewModel::getTokenSymbol() const
+{
+    return _tokenSymbol;
+}
+
+uint SendSwapViewModel::getTokenDecimals() const
+{
+    return _tokenDecimals;
+}
+
+bool SendSwapViewModel::isBeamAssetSwap() const
+{
+    return _beamAssetId != 0;
+}
+
+uint SendSwapViewModel::getBeamAssetId() const
+{
+    return static_cast<uint>(_beamAssetId);
+}
+
+QString SendSwapViewModel::getBeamAssetUnitName() const
+{
+    return _beamAssetUnitName;
+}
+
+bool SendSwapViewModel::needsBeamForRedeemFee() const
+{
+    return isBeamAssetSwap() && !isSendBeam();
+}
+
+bool SendSwapViewModel::isTokenSide(OldWalletCurrency::OldCurrency currency) const
+{
+    return currency == OldWalletCurrency::OldCurrency::CurrEthereum && !_tokenContract.isEmpty();
+}
+
+uint8_t SendSwapViewModel::effectiveDecimals(OldWalletCurrency::OldCurrency currency) const
+{
+    if (isTokenSide(currency))
+    {
+        // core stores AtomicSwapAmount in 10^min(decimals, 9) units per token
+        // (WalletUnitsPerToken, swaps/bridges/ethereum/common.cpp)
+        return std::min<uint8_t>(_tokenDecimals, 9);
+    }
+    return beamui::getCurrencyDecimals(convertCurrency(currency));
 }

--- a/ui/viewmodel/send_swap_view.cpp
+++ b/ui/viewmodel/send_swap_view.cpp
@@ -42,6 +42,30 @@ SendSwapViewModel::SendSwapViewModel()
     connect(_walletModel, &WalletModel::coinsSelected, this, &SendSwapViewModel::onCoinsSelected);
     connect(_rates.get(), SIGNAL(rateUnitChanged()), SIGNAL(secondCurrencyUnitNameChanged()));
     connect(_rates.get(), SIGNAL(activeRateChanged()), SIGNAL(secondCurrencyRateChanged()));
+
+    const auto onFeeRates = [this]()
+    {
+        ++_feeRatesRevision;
+        emit feeRatesRevisionChanged();
+    };
+    if (auto ethClient = AppModel::getInstance().getSwapEthClient(); ethClient)
+    {
+        connect(ethClient.get(), &SwapEthClientModel::estimatedFeeRateChanged, this, onFeeRates);
+    }
+    for (auto coin : {beam::wallet::AtomicSwapCoin::Bitcoin, beam::wallet::AtomicSwapCoin::Litecoin,
+                      beam::wallet::AtomicSwapCoin::Qtum, beam::wallet::AtomicSwapCoin::Dogecoin,
+                      beam::wallet::AtomicSwapCoin::Dash, beam::wallet::AtomicSwapCoin::Bitcoin_Cash})
+    {
+        if (auto client = AppModel::getInstance().getSwapCoinClient(coin); client)
+        {
+            connect(client.get(), &SwapCoinClientModel::estimatedFeeRateChanged, this, onFeeRates);
+        }
+    }
+}
+
+unsigned int SendSwapViewModel::getFeeRatesRevision() const
+{
+    return _feeRatesRevision;
 }
 
 QString SendSwapViewModel::getToken() const

--- a/ui/viewmodel/send_swap_view.cpp
+++ b/ui/viewmodel/send_swap_view.cpp
@@ -43,24 +43,11 @@ SendSwapViewModel::SendSwapViewModel()
     connect(_rates.get(), SIGNAL(rateUnitChanged()), SIGNAL(secondCurrencyUnitNameChanged()));
     connect(_rates.get(), SIGNAL(activeRateChanged()), SIGNAL(secondCurrencyRateChanged()));
 
-    const auto onFeeRates = [this]()
+    swapui::connectFeeRateClients(this, [this]()
     {
         ++_feeRatesRevision;
         emit feeRatesRevisionChanged();
-    };
-    if (auto ethClient = AppModel::getInstance().getSwapEthClient(); ethClient)
-    {
-        connect(ethClient.get(), &SwapEthClientModel::estimatedFeeRateChanged, this, onFeeRates);
-    }
-    for (auto coin : {beam::wallet::AtomicSwapCoin::Bitcoin, beam::wallet::AtomicSwapCoin::Litecoin,
-                      beam::wallet::AtomicSwapCoin::Qtum, beam::wallet::AtomicSwapCoin::Dogecoin,
-                      beam::wallet::AtomicSwapCoin::Dash, beam::wallet::AtomicSwapCoin::Bitcoin_Cash})
-    {
-        if (auto client = AppModel::getInstance().getSwapCoinClient(coin); client)
-        {
-            connect(client.get(), &SwapCoinClientModel::estimatedFeeRateChanged, this, onFeeRates);
-        }
-    }
+    });
 }
 
 unsigned int SendSwapViewModel::getFeeRatesRevision() const
@@ -423,11 +410,7 @@ bool SendSwapViewModel::isEnough() const
     {
         if (isTokenSide(_sendCurrency))
         {
-            // no live balance for arbitrary custom tokens: only check the ETH
-            // that pays the lock gas (incl. the approve calls, kApproveTxGasLimit)
-            const beam::Amount lockFee = _sendFeeGrothes *
-                (beam::ethereum::kLockTxGasLimit + 2 * beam::ethereum::kApproveTxGasLimit);
-            return AppModel::getInstance().getSwapEthClient()->getAvailable(beam::wallet::AtomicSwapCoin::Ethereum) >= lockFee;
+            return swapui::enoughEthForTokenLock(_sendFeeGrothes);
         }
 
         if (_sendCurrency == OldWalletCurrency::OldCurrency::CurrEthereum)
@@ -679,16 +662,10 @@ bool SendSwapViewModel::needsBeamForRedeemFee() const
 
 bool SendSwapViewModel::isTokenSide(OldWalletCurrency::OldCurrency currency) const
 {
-    return currency == OldWalletCurrency::OldCurrency::CurrEthereum && !_tokenContract.isEmpty();
+    return swapui::isTokenSide(currency, _tokenContract);
 }
 
 uint8_t SendSwapViewModel::effectiveDecimals(OldWalletCurrency::OldCurrency currency) const
 {
-    if (isTokenSide(currency))
-    {
-        // core stores AtomicSwapAmount in 10^min(decimals, 9) units per token
-        // (WalletUnitsPerToken, swaps/bridges/ethereum/common.cpp)
-        return std::min<uint8_t>(_tokenDecimals, 9);
-    }
-    return beamui::getCurrencyDecimals(convertCurrency(currency));
+    return swapui::effectiveSwapDecimals(currency, _tokenContract, _tokenDecimals);
 }

--- a/ui/viewmodel/send_swap_view.h
+++ b/ui/viewmodel/send_swap_view.h
@@ -55,6 +55,15 @@ class SendSwapViewModel: public QObject
     Q_PROPERTY(unsigned int minimalBeamFeeGrothes           READ getMinimalBeamFeeGrothes       NOTIFY minimalBeamFeeGrothesChanged)
     Q_PROPERTY(QList<QMap<QString, QVariant>> currList      READ getCurrList                    NOTIFY  currListChanged)
 
+    Q_PROPERTY(bool    isErc20Swap        READ isErc20Swap        NOTIFY tokenChanged)
+    Q_PROPERTY(QString tokenContract      READ getTokenContract   NOTIFY tokenChanged)
+    Q_PROPERTY(QString tokenSymbol        READ getTokenSymbol     NOTIFY tokenChanged)
+    Q_PROPERTY(uint    tokenDecimals      READ getTokenDecimals   NOTIFY tokenChanged)
+    Q_PROPERTY(bool    isBeamAssetSwap    READ isBeamAssetSwap    NOTIFY tokenChanged)
+    Q_PROPERTY(uint    beamAssetId        READ getBeamAssetId     NOTIFY tokenChanged)
+    Q_PROPERTY(QString beamAssetUnitName  READ getBeamAssetUnitName NOTIFY tokenChanged)
+    Q_PROPERTY(bool    needsBeamForRedeemFee READ needsBeamForRedeemFee NOTIFY tokenChanged)
+
 public:
     SendSwapViewModel();
 
@@ -113,6 +122,15 @@ public:
     QString getReceiveFeeTitle() const;
     QList<QMap<QString, QVariant>> getCurrList() const;
 
+    bool isErc20Swap() const;
+    QString getTokenContract() const;
+    QString getTokenSymbol() const;
+    uint getTokenDecimals() const;
+    bool isBeamAssetSwap() const;
+    uint getBeamAssetId() const;
+    QString getBeamAssetUnitName() const;
+    bool needsBeamForRedeemFee() const;
+
 public:
     Q_INVOKABLE void setParameters(const QVariant& parameters);    /// used to pass TxParameters directly without Token generation
     Q_INVOKABLE void sendMoney();
@@ -148,6 +166,11 @@ private:
     void fillParameters(const beam::wallet::TxParameters& parameters);
     void recalcAvailable();
 
+    // true when @currency is the pair side the offer's custom ERC-20 token rides on
+    bool isTokenSide(OldWalletCurrency::OldCurrency currency) const;
+    // token side -> min(token decimals, 9) (WalletUnitsPerToken rule), otherwise the classic table
+    uint8_t effectiveDecimals(OldWalletCurrency::OldCurrency currency) const;
+
     beam::Amount _sendAmountGrothes;
     beam::Amount _sendFeeGrothes;
     OldWalletCurrency::OldCurrency _sendCurrency;
@@ -169,4 +192,12 @@ private:
 
     beam::Amount _minimalBeamFeeGrothes;
     bool _feeChangedByUI = false;
+
+    // extended-offer fields (params 41-45), empty/0 when the offer is a
+    // classic swap
+    QString _tokenContract;
+    QString _tokenSymbol;
+    uint8_t _tokenDecimals = 0;
+    beam::Asset::ID _beamAssetId = 0;
+    QString _beamAssetUnitName;
 };

--- a/ui/viewmodel/send_swap_view.h
+++ b/ui/viewmodel/send_swap_view.h
@@ -63,6 +63,8 @@ class SendSwapViewModel: public QObject
     Q_PROPERTY(uint    beamAssetId        READ getBeamAssetId     NOTIFY tokenChanged)
     Q_PROPERTY(QString beamAssetUnitName  READ getBeamAssetUnitName NOTIFY tokenChanged)
     Q_PROPERTY(bool    needsBeamForRedeemFee READ needsBeamForRedeemFee NOTIFY tokenChanged)
+    // bumped on estimatedFeeRateChanged so QML fee bindings re-evaluate
+    Q_PROPERTY(unsigned int feeRatesRevision  READ getFeeRatesRevision NOTIFY feeRatesRevisionChanged)
 
 public:
     SendSwapViewModel();
@@ -130,6 +132,7 @@ public:
     uint getBeamAssetId() const;
     QString getBeamAssetUnitName() const;
     bool needsBeamForRedeemFee() const;
+    unsigned int getFeeRatesRevision() const;
 
 public:
     Q_INVOKABLE void setParameters(const QVariant& parameters);    /// used to pass TxParameters directly without Token generation
@@ -157,6 +160,7 @@ signals:
     void tokenGeneratebByNewAppVersion();
     void minimalBeamFeeGrothesChanged();
     void currListChanged();
+    void feeRatesRevisionChanged();
 
 public slots:
     void onChangeCalculated(beam::Amount changeAsset, beam::Amount changeBeam, beam::Asset::ID assetId);
@@ -192,6 +196,7 @@ private:
 
     beam::Amount _minimalBeamFeeGrothes;
     bool _feeChangedByUI = false;
+    unsigned int _feeRatesRevision = 0;
 
     // extended-offer fields (params 41-45), empty/0 when the offer is a
     // classic swap

--- a/ui/viewmodel/ui_helpers.cpp
+++ b/ui/viewmodel/ui_helpers.cpp
@@ -131,6 +131,18 @@ namespace beamui
         return QString::fromStdString(samount) + (unitName.isEmpty() ? "" : " " + unitName);
     }
 
+    QString AmountToUIStringExactDecimals(const Amount& value, uint8_t decimalPlaces)
+    {
+        return QString::fromStdString(libbitcoin::encode_base10(value, decimalPlaces));
+    }
+
+    beam::Amount UIStringToAmountExactDecimals(const QString& value, uint8_t decimalPlaces)
+    {
+        beam::Amount amount = 0;
+        libbitcoin::decode_base10(amount, value.toStdString(), decimalPlaces, true);
+        return amount;
+    }
+
      QString AmountBigToUIString(const beam::AmountBig::Number& value)
      {
         beam::wallet::PrintableAmount print(value, true);
@@ -464,6 +476,22 @@ namespace beamui
 
         //% "Online"
         return qtTrId("tx-regular");
+    }
+
+    QColor ColorFromString(const QString& identifier)
+    {
+        // same fixed palette AssetsManager uses for Confidential Assets (assets_manager.cpp),
+        // indexed by a hash of the identifier instead of a numeric asset id -- keeps custom
+        // ERC-20 token icons visually consistent with the rest of the app, purely locally.
+        static const QColor palette[] = {
+            QColor("#72fdff"), QColor("#2acf1d"), QColor("#ffbb54"), QColor("#d885ff"), QColor("#008eff"),
+            QColor("#ff746b"), QColor("#91e300"), QColor("#ffe75a"), QColor("#9643ff"), QColor("#395bff"),
+            QColor("#ff3b3b"), QColor("#73ff7c"), QColor("#ffa86c"), QColor("#ff3abe"), QColor("#00aee1"),
+            QColor("#ff5200"), QColor("#6464ff"), QColor("#ff7a21"), QColor("#63afff"), QColor("#c81f68")
+        };
+        constexpr int paletteSize = sizeof(palette) / sizeof(palette[0]);
+        const auto idx = static_cast<uint32_t>(qHash(identifier.toLower())) % paletteSize;
+        return palette[idx];
     }
 
     QString getReasonString(beam::wallet::TxFailureReason reason)

--- a/ui/viewmodel/ui_helpers.h
+++ b/ui/viewmodel/ui_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QObject>
+#include <QColor>
 #include <QQmlListProperty>
 #include "wallet/core/common.h"
 #ifdef BEAM_ATOMIC_SWAP_SUPPORT
@@ -74,6 +75,9 @@ namespace beamui
     /// Convert amount to ui string with "." as a separator. With the default @coinType, no currency label added.
     QString AmountToUIString(const beam::Amount& value, Currencies coinType = Currencies::Unknown, bool currencyLabel = true);
     QString AmountToUIString(const beam::Amount& value, const QString& unitName, uint8_t decimalPlaces = 0);
+    /// exact-decimals conversions: 0 is a valid decimal count here, unlike the overloads above/below
+    QString AmountToUIStringExactDecimals(const beam::Amount& value, uint8_t decimalPlaces);
+    beam::Amount UIStringToAmountExactDecimals(const QString& value, uint8_t decimalPlaces);
     QString AmountBigToUIString(const beam::AmountBig::Number& value);
 
     // value -> s"value GROTH"
@@ -102,6 +106,11 @@ namespace beamui
     quint32 getCurrentUIRevision();
 
     QString GetTokenTypeUIString(const std::string& token, bool choiceOffline);
+
+    // deterministic, local-only color for a string identifier (e.g. an ERC-20 contract
+    // address), drawn from the same fixed palette AssetsManager uses for Confidential
+    // Assets -- no network lookups, so the same address always maps to the same color.
+    QColor ColorFromString(const QString& identifier);
 
     QString getReasonString(beam::wallet::TxFailureReason reason);
 }  // namespace beamui

--- a/ui/viewmodel/ui_helpers.h
+++ b/ui/viewmodel/ui_helpers.h
@@ -77,6 +77,13 @@ namespace beamui
     QString AmountToUIString(const beam::Amount& value, const QString& unitName, uint8_t decimalPlaces = 0);
     /// exact-decimals conversions: 0 is a valid decimal count here, unlike the overloads above/below
     QString AmountToUIStringExactDecimals(const beam::Amount& value, uint8_t decimalPlaces);
+
+    // token amounts are quoted in wallet units, min(decimals, 9) fractional
+    // digits (WalletUnitsPerToken rule, wallet/transactions/swaps/common.cpp)
+    constexpr uint8_t tokenWalletDecimals(uint32_t onChainDecimals)
+    {
+        return onChainDecimals < 9u ? static_cast<uint8_t>(onChainDecimals) : uint8_t(9);
+    }
     beam::Amount UIStringToAmountExactDecimals(const QString& value, uint8_t decimalPlaces);
     QString AmountBigToUIString(const beam::AmountBig::Number& value);
 


### PR DESCRIPTION
> [!WARNING]
DO NOT MERGE UNTIL https://github.com/BeamMW/beam/pull/2075 IS MERGED.

UI side of the atomic-swap repair and extension tracked in #1267. **Depends on BeamMW/beam PR `issue/2070`** — the submodule bump in this branch points at its head; merge that PR first. One commit per issue plus small standalone fix and cleanup commits.

### What's in here

**#1017 / #1073 — offer publishing restored (submodule bump).** Brings the core-side fixes: persisted swap offer publisher address (publishing has thrown `ForeignOfferException` since 7.3), CLI swap-coin balance validation, the post-funding lock-tx fee-rate check, the fly_client kernel-check fix that unbreaks swap redeems, the generic Ethereum JSON-RPC endpoint, and the core half of any-asset/any-token swaps.

**#1129 — first-person labels.** Swap amounts are always rendered from the viewer's perspective, but the bare SEND/RECEIVE labels left it ambiguous. The atomic-swap and asset-swap offer tables and the swap create/accept screens (including the token info dialog) now read I SEND / I RECEIVE. Obsolete string ids with no remaining references were dropped; the shared `general-send` id is untouched.

**#1107 — settings section title.** "Ethereum node" → "Ethereum" (the section configures the account seed and tokens, not just a node).

**BeamMW/beam#1103 — in-progress swap safety note.** While coins are locked, the swap details show: "While the swap is in progress, if the other side goes offline your coins will be automatically unlocked in %1 at most." The figure derives from the actual refund-height window (the same computation as the existing in-progress state details), never a hardcoded value, and disappears in terminal states.

**#1268 — Ethereum connectivity: Infura or any JSON-RPC endpoint.** A provider switcher (same pattern as the Node ↔ Electrum switch): Infura keeps the project-ID flow unchanged; Custom RPC takes any endpoint URL (Alchemy, QuickNode, Chainstack, Ankr, self-hosted). A "Check connection" button reports the detected chain and latest block (`eth_chainId`/`eth_blockNumber`) before any swap is attempted; wrong-network endpoints are called out explicitly ("Connected to %1, but Ethereum Mainnet is required"); feedback clears whenever the endpoint fields change, and the check is disabled while edits are unapplied.

**#1166 — any Confidential Asset and any ERC-20 token.** - Offer creation: the wallet's Confidential Assets and stored custom tokens appear as regular entries in the main currency dropdowns, with their real icons — no separate picker. Assets ride the BEAM side (either direction); balance checks run against the asset, fee checks against BEAM. - Ethereum settings: an add-custom-token flow — enter a contract address, the wallet reads `symbol()`/`decimals()` from the contract for confirmation; tokens are stored per wallet and offered as swap currencies. Token amounts convert with the token's real decimals end-to-end. - Accepting: the confirmation screens show the offered token's contract address, symbol and decimals with an explicit warning ("Verify this token contract address carefully. Anyone can create a token with any name."), and the Beam-side asset id/unit name; receiving an asset warns that a small BEAM balance is required for the redeem fee and validates it. - Accepting an asset offer runs its balance/change/fee computations against the offer's asset (BEAM only for the fee), and the redeem-fee BEAM check applies on whichever side receives the asset. - Offer list, rate, currency filter and fit-my-balance are asset- and token-aware with real symbols (contract matching is case-insensitive for EIP-55 addresses), including in-flight swaps on the transactions tab. - Custom-token balance cards on the swaps screen show live balances and the same connection states/settings link as the built-in coin cards.

**Settings UX.** "Connect more currencies" no longer unfolds every unconnected coin's settings section at once; it navigates with all sections folded (explicit per-coin links still unfold their own section).

**Fee-panel fixes.** - The recommended fee rate refreshes live: the swap screens re-query the cached rate whenever a swap-coin client reports a new estimate (previously a one-shot read at screen load — opening the screen before the first `eth_gasPrice` response left "0 / connection error" stuck forever), and an untouched, unfocused fee input adopts the recommendation when it arrives (a field the user is editing is never overwritten). - The fee unit label ("gwei" etc.) is a proper layout child again instead of a zero-sized overlay hack that bled outside the panel on fill-width inputs. - Receiving on the Ethereum side with too little ETH for the redeem-tx gas now says exactly that — "Not enough ETH to pay the redeem transaction fee (%1 needed)" — instead of the generic not-enough-funds message, and ETH-side withdraw fees render in ETH rather than six-digit gwei.

**Cleanups.** Two refactor commits dedupe what the feature work introduced: one `tokenWalletDecimals()` for the min(decimals, 9) wire-units rule, shared ERC-20 symbol/amount formatting and token-side helpers in `swap_utils`, the token-info lookup folded into core `Client` (`GetTokenInfo`/`OnTokenInfo`) instead of a parallel reactor bridge in the UI model, `getDefaultFee` delegating to `getRecommendedFee`, and the endpoint-check feedback bound directly to the settings viewmodel.

### i18n

All new strings are id-based with English sources; every locale except `rs_RS.ts` regenerated via lupdate; `en_US.ts` entries finished.

### Testing / QA

The branch builds end-to-end with the bumped submodule (macOS). Core-side behavior is covered by the beam PR's test suites (including CA swaps in both directions against a real node). UI-side manual QA checklist:

- Offer tables and create/accept screens show I SEND / I RECEIVE (atomic + asset swaps, own + foreign offers).
- Create Offer: a Confidential Asset and a custom token are pickable in the main currency dropdowns (icons, correct decimals); the recommended Ethereum fee rate fills in by itself once the endpoint responds.
- Ethereum settings: switcher round-trip; Check connection against a valid endpoint (✓ with chain + block), a garbage URL (✗), and a non-mainnet endpoint on a mainnet build (explicit wrong-network message); settings persist across restart.
- A live custom-token swap: add token in settings, publish an offer, verify the ERC-20 panel and warning on the accepting wallet, confirm the on-chain amount matches the typed value for a token with fewer than 9 decimals.
- A CA swap on testnet: pick the asset in the currency dropdown, acceptor sees asset id/unit name and the BEAM-fee note, transactions tab shows the asset unit name while in flight.
- Swap details during any swap: the auto-unlock note appears while locked and disappears on completion.

Closes #1017, #1073, #1129, #1107, #1268, #1166. Closes BeamMW/beam#1103. Part of #1267.
